### PR TITLE
Add TextField.validation_message and validity?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 Thumbs.db
 
 #IDE project files
-/.idea
+.idea/
 .settings
 .project
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 All notable changes to this project will be documented in this file.
 
 
+## [4.2.0] - 20-APR-2022
+
+### Added
+* `TextField.validation_message` and `TextField.validity?` methods added.
+* Updated `PageObject.verify_ui_states` and `PageSection.verify_ui_states` methods to support verification of the following
+`TextField.validity?` properties:
+  * `:badInput`
+  * `:customError`
+  * `:patternMismatch`
+  * `:rangeOverflow`
+  * `:rangeUnderflow`
+  * `:stepMismatch`
+  * `:tooLong`
+  * `:tooShort`
+  * `:typeMismatch`
+  * `:valid`
+  * `:valueMissing`
+
+
 ## [4.1.10] - 19-APR-2022
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ can be found [here](https://github.com/TestCentricity/tc_web_sample).
 
 ## Installation
 
-TestCentricity version 4.1 and above requires Ruby 2.7 or later. To install the TestCentricity gem, add this line to your automation project's Gemfile:
+TestCentricity version 4.1 and above requires Ruby 2.7.5 or later. To install the TestCentricity gem, add this line to your automation project's Gemfile:
 
     gem 'testcentricity_web'
 
@@ -658,6 +658,22 @@ The `verify_ui_states` method supports the following property/state pairs:
     :min         Integer
     :max         Integer
     :step        Integer
+
+  Text Field Constraint validation
+
+    :validation_message String
+    :badInput           Boolean
+    :customError        Boolean
+    :patternMismatch    Boolean
+    :rangeOverflow      Boolean
+    :rangeUnderflow     Boolean
+    :stepMismatch       Boolean
+    :tooLong            Boolean
+    :tooShort           Boolean
+    :typeMismatch       Boolean
+    :valid              Boolean
+    :valueMissing       Boolean
+
 
 **Checkboxes:**
 

--- a/features/basic_form_page_css.feature
+++ b/features/basic_form_page_css.feature
@@ -24,6 +24,20 @@ Feature: Basic HTML Form Test Page using CSS locators
     Then I expect the Basic CSS Form page to be correctly displayed
 
 
+  Scenario Outline: Verify text field constraint validation
+    When I populate the form fields with <reason>
+    And I submit my changes
+    Then I expect an error to be displayed due to <reason>
+
+    Examples:
+      |reason          |
+      |blank username  |
+      |blank password  |
+      |number too low  |
+      |number too high |
+      |invalid email   |
+
+
   Scenario Outline:  Choose selectlist options by index, value, and text
     When I choose selectlist options by <method>
     Then I expect the selected option to be displayed

--- a/features/step_definitions/generic_steps.rb.rb
+++ b/features/step_definitions/generic_steps.rb.rb
@@ -122,3 +122,13 @@ end
 Then(/^I expect the selected option to be displayed$/) do
   PageManager.current_page.verify_chosen_options
 end
+
+
+When(/^I populate the form fields with (.*)$/) do |reason|
+  PageManager.current_page.invalid_data_entry(reason)
+end
+
+
+Then(/^I expect an error to be displayed due to (.*)$/) do |reason|
+  PageManager.current_page.verify_entry_error(reason)
+end

--- a/features/support/pages/basic_form_page.rb
+++ b/features/support/pages/basic_form_page.rb
@@ -149,8 +149,8 @@ class BasicFormPage < BaseTestPage
     image_1.wait_until_loaded(5)
     username_field.scroll_to(:center) if username_field.obscured?
     ui = {
-      username_label    => { visible: true, caption: 'Username:' },
-      username_field    => {
+      username_label => { visible: true, caption: 'Username:' },
+      username_field => {
         name: 'username',
         exists: true,
         displayed: true,
@@ -161,10 +161,21 @@ class BasicFormPage < BaseTestPage
         disabled: false,
         required: true,
         value: '',
-        placeholder: 'User name'
+        placeholder: 'User name',
+        badInput: false,
+        customError: false,
+        patternMismatch: false,
+        rangeOverflow: false,
+        rangeUnderflow: false,
+        stepMismatch: false,
+        tooLong: false,
+        tooShort: false,
+        typeMismatch: false,
+        valid: false,
+        valueMissing: true
       },
-      password_label    => { visible: true, caption: 'Password:' },
-      password_field    => {
+      password_label => { visible: true, caption: 'Password:' },
+      password_field => {
         name: 'password',
         visible: true,
         displayed: true,
@@ -175,8 +186,8 @@ class BasicFormPage < BaseTestPage
         value: '',
         placeholder: 'Password'
       },
-      max_length_label  => { visible: true, caption: 'Max Length:' },
-      max_length_field  => {
+      max_length_label => { visible: true, caption: 'Max Length:' },
+      max_length_field => {
         visible: true,
         obscured: false,
         enabled: true,
@@ -185,38 +196,39 @@ class BasicFormPage < BaseTestPage
         value: '',
         maxlength: 64
       },
-      read_only_label   => { visible: true, caption: 'Read Only:' },
-      read_only_field   => {
+      read_only_label => { visible: true, caption: 'Read Only:' },
+      read_only_field => {
         visible: true,
         enabled: true,
         readonly: true,
         value: 'I am a read only text field'
       },
-      number_label      => { visible: true, caption: 'Number:' },
-      number_field      => {
+      number_label => { visible: true, caption: 'Number:' },
+      number_field => {
         visible: true,
         enabled: true,
         value: '41',
         min: 10,
         max: 1024,
-        step: 1
+        step: 1,
+        validation_message: ''
       },
-      color_label       => { visible: true, caption: 'Color:' },
-      color_picker      => { visible: true, enabled: true, value: '#000000' },
-      slider_label      => { visible: true, caption: 'Range:' },
-      slider            => {
+      color_label => { visible: true, caption: 'Color:' },
+      color_picker => { visible: true, enabled: true, value: '#000000' },
+      slider_label => { visible: true, caption: 'Range:' },
+      slider => {
         visible: true,
         enabled: true,
         value: 25,
         min: 0,
         max: 50,
       },
-      comments_label    => { visible: true, caption: 'TextArea:' },
-      comments_field    => { visible: true, enabled: true, value: '' },
-      filename_label    => { visible: true, caption: 'Filename:' },
-      upload_file       => { visible: true, enabled: true, value: '' },
-      checkboxes_label  => { visible: true, caption: 'Checkbox Items:' },
-      check_1           => {
+      comments_label => { visible: true, caption: 'TextArea:' },
+      comments_field => { visible: true, enabled: true, value: '' },
+      filename_label => { visible: true, caption: 'Filename:' },
+      upload_file => { visible: true, enabled: true, value: '' },
+      checkboxes_label => { visible: true, caption: 'Checkbox Items:' },
+      check_1 => {
         exists: true,
         visible: true,
         hidden: false,
@@ -225,7 +237,7 @@ class BasicFormPage < BaseTestPage
         checked: false,
         indeterminate: false
       },
-      check_2           => {
+      check_2 => {
         exists: true,
         visible: true,
         hidden: false,
@@ -234,7 +246,7 @@ class BasicFormPage < BaseTestPage
         checked: false,
         indeterminate: false
       },
-      check_3           => {
+      check_3 => {
         exists: true,
         visible: true,
         hidden: false,
@@ -243,7 +255,7 @@ class BasicFormPage < BaseTestPage
         checked: false,
         indeterminate: false
       },
-      check_4           => {
+      check_4 => {
         exists: true,
         visible: true,
         hidden: false,
@@ -252,8 +264,8 @@ class BasicFormPage < BaseTestPage
         checked: false,
         indeterminate: false
       },
-      radios_label      => { visible: true, caption: 'Radio Items:' },
-      radio_1           => {
+      radios_label => { visible: true, caption: 'Radio Items:' },
+      radio_1 => {
         exists: true,
         visible: true,
         hidden: false,
@@ -261,7 +273,7 @@ class BasicFormPage < BaseTestPage
         disabled: false,
         selected: false
       },
-      radio_2           => {
+      radio_2 => {
         exists: true,
         visible: true,
         hidden: false,
@@ -269,7 +281,7 @@ class BasicFormPage < BaseTestPage
         disabled: false,
         selected: false
       },
-      radio_3           => {
+      radio_3 => {
         exists: true,
         visible: true,
         hidden: false,
@@ -277,7 +289,7 @@ class BasicFormPage < BaseTestPage
         disabled: false,
         selected: false
       },
-      radio_4           => {
+      radio_4 => {
         exists: true,
         visible: true,
         hidden: false,
@@ -286,46 +298,46 @@ class BasicFormPage < BaseTestPage
         selected: false
       },
       multiselect_label => { visible: true, caption: 'Multiple Select Values:' },
-      multi_select      => {
+      multi_select => {
         visible: true,
         enabled: true,
         optioncount: 4,
         options: ['Selection Item 1', 'Selection Item 2', 'Selection Item 3', 'Selection Item 4'],
         selected: ''
       },
-      dropdown_label    => { visible: true, caption: 'Dropdown:' },
-      drop_down_select  => {
+      dropdown_label => { visible: true, caption: 'Dropdown:' },
+      drop_down_select => {
         visible: true,
         enabled: true,
         optioncount: 6,
         options: ['Drop Down Item 1', 'Drop Down Item 2', 'Drop Down Item 3', 'Drop Down Item 4', 'Drop Down Item 5', 'Drop Down Item 6'],
         selected: 'Drop Down Item 1'
       },
-      link_label        => { visible: true, caption: 'Links:' },
-      links_list        => {
+      link_label => { visible: true, caption: 'Links:' },
+      links_list => {
         visible: true,
         enabled: true,
         itemcount: 3,
         items: ['Open Media Page in same window/tab', 'Open Media Page in a new window/tab', 'Disabled Link']
       },
-      link_1            => {
+      link_1 => {
         visible: true,
         href: { ends_with: 'media_page.html' },
         caption: 'Open Media Page in same window/tab'
       },
-      link_2            => {
+      link_2 => {
         visible: true,
         href: { ends_with: 'media_page.html' },
         caption: 'Open Media Page in a new window/tab'
       },
-      link_3            => {
+      link_3 => {
         visible: true,
         aria_disabled: true,
         role: 'link',
         caption: 'Disabled Link'
       },
-      table_label       => { visible: true, caption: 'Table:' },
-      static_table      => {
+      table_label => { visible: true, caption: 'Table:' },
+      static_table => {
         visible: true,
         columncount: 3,
         rowcount: 4,
@@ -338,29 +350,29 @@ class BasicFormPage < BaseTestPage
         { cell: [2, 3] } => ['Mexico'],
         { column: 3 } => [['Germany', 'Mexico', 'Austria', 'UK']]
       },
-      images_label      => { visible: true, caption: 'Images:' },
-      image_1           => {
+      images_label => { visible: true, caption: 'Images:' },
+      image_1 => {
         visible: true,
         loaded: true,
         broken: false,
         src: { ends_with: 'images/Wilder.jpg' },
         alt: "It's alive"
       },
-      image_2           => {
+      image_2 => {
         visible: true,
         loaded: true,
         broken: false,
         src: { ends_with: 'images/You_Betcha.jpg' },
         alt: 'You Betcha'
       },
-      image_3           => {
+      image_3 => {
         visible: true,
         broken: true,
         src: { ends_with: 'wrongname.gif' },
         alt: 'A broken image'
       },
-      cancel_button     => { visible: true, enabled: true, caption: 'Cancel' },
-      submit_button     => { visible: true, enabled: true, caption: 'Submit' }
+      cancel_button => { visible: true, enabled: true, caption: 'Cancel' },
+      submit_button => { visible: true, enabled: true, caption: 'Submit' }
     }
     verify_ui_states(ui)
   end
@@ -495,6 +507,51 @@ class BasicFormPage < BaseTestPage
       multi_select     => { selected: 'Selection Item 2' },
       drop_down_select => { selected: 'Drop Down Item 3' }
     }
+    verify_ui_states(ui)
+  end
+
+  def invalid_data_entry(reason)
+    # populate fields and controls with externally sourced data
+    @data = form_data
+    fields = {
+      username_field => @data[:username],
+      password_field => @data[:password],
+      number_field => @data[:number]
+    }
+    populate_data_fields(fields)
+
+    case reason.gsub(/\s+/, '_').downcase.to_sym
+    when :blank_username
+      username_field.clear
+    when :blank_password
+      password_field.clear
+    when :number_too_low
+      number_field.set(3)
+    when :number_too_high
+      number_field.set(4132)
+    when :invalid_email
+      email_field.set('bob')
+    else
+      raise "#{reason} is not a valid selector"
+    end
+  end
+
+  def verify_entry_error(reason)
+    ui = case reason.gsub(/\s+/, '_').downcase.to_sym
+         when :blank_username
+           { username_field => { valid: false, valueMissing: true } }
+         when :blank_password
+           { password_field => { valid: false, valueMissing: true } }
+         when :number_too_low
+           { number_field => { valid: false, rangeUnderflow: true } }
+         when :number_too_high
+           { number_field => { valid: false, rangeOverflow: true } }
+         when :invalid_email
+           { email_field => { valid: false, typeMismatch: true } }
+         else
+           raise "#{reason} is not a valid selector"
+         end
+    # verify correct error message is displayed
     verify_ui_states(ui)
   end
 end

--- a/lib/testcentricity_web/web_core/page_objects_helper.rb
+++ b/lib/testcentricity_web/web_core/page_objects_helper.rb
@@ -231,6 +231,30 @@ module TestCentricity
                      ui_object.aria_multiselectable?
                    when :content_editable
                      ui_object.content_editable?
+                   when :validation_message
+                     ui_object.validation_message
+                   when :badInput
+                     ui_object.validity?(:badInput)
+                   when :customError
+                     ui_object.validity?(:customError)
+                   when :patternMismatch
+                     ui_object.validity?(:patternMismatch)
+                   when :rangeOverflow
+                     ui_object.validity?(:rangeOverflow)
+                   when :rangeUnderflow
+                     ui_object.validity?(:rangeUnderflow)
+                   when :stepMismatch
+                     ui_object.validity?(:stepMismatch)
+                   when :tooLong
+                     ui_object.validity?(:tooLong)
+                   when :tooShort
+                     ui_object.validity?(:tooShort)
+                   when :typeMismatch
+                     ui_object.validity?(:typeMismatch)
+                   when :valid
+                     ui_object.validity?(:valid)
+                   when :valueMissing
+                     ui_object.validity?(:valueMissing)
                    else
                      if property.is_a?(Hash)
                        property.map do |key, value|

--- a/lib/testcentricity_web/web_elements/textfield.rb
+++ b/lib/testcentricity_web/web_elements/textfield.rb
@@ -42,6 +42,34 @@ module TestCentricity
       obj.native.attribute('placeholder')
     end
 
+    # Return validationMessage property of a textfield, which is the message the browser displays to the user when a textfield's
+    # validity is checked and fails. Note that each web browser provides a default localized message for this property, and message
+    # strings can vary between different browsers (Chrome/Edge vs Firefox vs Safari).
+    #
+    # @return [String]
+    # @example
+    #   message = username_field.validation_message
+    #
+    def validation_message
+      obj, = find_element
+      object_not_found_exception(obj, nil)
+      obj.native.attribute('validationMessage')
+    end
+
+    # Return Boolean value representing
+    #
+    # @param validity_state [Symbol] property to verify
+    # @return [Boolean]
+    # @example
+    #   username_field.validity?(:valid)
+    #   username_field.validity?(:valueMissing)
+    #
+    def validity?(validity_state)
+      obj, = find_element
+      object_not_found_exception(obj, nil)
+      page.execute_script("return arguments[0].validity.#{validity_state}", obj)
+    end
+
     # Return min attribute of a number type text field.
     #
     # @return [Integer]

--- a/testcentricity_web.gemspec
+++ b/testcentricity_web.gemspec
@@ -23,6 +23,10 @@ Gem::Specification.new do |spec|
     LambdaTest services).'
   spec.homepage      = 'https://github.com/TestCentricity/testcentricity_web'
   spec.license       = 'BSD-3-Clause'
+  spec.metadata = {
+    'changelog_uri' => 'https://github.com/TestCentricity/testcentricity_web/blob/main/CHANGELOG.md',
+    'documentation_uri' => 'https://www.rubydoc.info/gems/testcentricity_web'
+  }
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
* `TextField.validation_message` and `validity?` methods added.
* Updated `PageObject.verify_ui_states` and `PageSection.verify_ui_states` methods to support verification of `TextField.validation_message` and `TextField.validity?` properties.
* Updated cukes to verify new `TextField` validation methods and changes to `verify_ui_states`.
* Add `changelog_uri` and `documentation_uri` gemspec metadata.