### PR TITLE
Media methods to support verification of media text tracks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ Thumbs.db
 /spec/reports/
 /tmp/
 Gemfile*.lock
+*gem
 
 # rspec failure tracking
 .rspec_status

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 All notable changes to this project will be documented in this file.
 
 
+## [4.2.1] - 23-APR-2022
+
+### Added
+* Added the following `Audio`, `Media`, and `Video` methods to support verification of media text tracks (subtitles, captions,
+chapters, descriptions, or metadata):
+  * `track_count`
+  * `active_track`
+  * `active_track_data`
+  * `all_tracks_data`
+  * `track_data`
+  * `active_track_source`
+  * `track_source`
+* Updated `PageObject.verify_ui_states` and `PageSection.verify_ui_states` methods to support verification of the following
+  `Media` properties:
+  * `:track_count`
+  * `:active_track`
+  * `:active_track_data`
+  * `:all_tracks_data`
+  * `:track_data`
+  * `:active_track_source`
+  * `:track_source`
+
+
 ## [4.2.0] - 20-APR-2022
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # TestCentricity™ Web
 
 [![Gem Version](https://badge.fury.io/rb/testcentricity_web.svg)](https://badge.fury.io/rb/testcentricity_web)  [![License (3-Clause BSD)](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg?style=flat-square)](http://opensource.org/licenses/BSD-3-Clause)
+![Gem Downloads](https://img.shields.io/gem/dt/testcentricity_web) ![Maintained](https://img.shields.io/maintenance/yes/2022)
 
 
 The TestCentricity™ Web core generic framework for desktop and mobile web browser-based app testing implements a Page Object Model DSL
@@ -738,6 +739,13 @@ The `verify_ui_states` method supports the following property/state pairs:
     :volume                Float
     :preload               String
     :poster                String
+    :track_count           Integer
+    :active_track          Integer
+    :active_track_data     Hash
+    :all_tracks_data       Array of Hash
+    :track_data            Hash
+    :active_track_source   String
+    :track_source          String
 
 #### ARIA accessibility property/state pairs
 

--- a/features/support/pages/media_test_page.rb
+++ b/features/support/pages/media_test_page.rb
@@ -8,7 +8,8 @@ class MediaTestPage < BaseTestPage
   trait(:page_title)   { 'Media Page'}
 
   # Media Test page UI elements
-  videos  video_player_1: 'video#video_player1'
+  videos  video_player_1: 'video#video_player1',
+          video_player_2: 'video#video_player2'
   audios  audio_player:   'audio#audio_player'
 
   def verify_page_ui
@@ -45,7 +46,43 @@ class MediaTestPage < BaseTestPage
         preload: preload,
         poster: '',
         src: '',
-        duration: 17.6
+        duration: 17.6,
+        track_count: 0,
+        active_track: 0
+      },
+      video_player_2 => {
+        visible: true,
+        paused: true,
+        autoplay: false,
+        loop: false,
+        ended: false,
+        controls: true,
+        current_time: 0,
+        ready_state: 4,
+        default_playback_rate: 1,
+        playback_rate: 1,
+        seeking: false,
+        default_muted: false,
+        muted: false,
+        volume: 1,
+        preload: preload,
+        poster: '',
+        src: '',
+        duration: 120,
+        track_count: 3,
+        active_track: 1,
+        active_track_data: {
+          kind: 'subtitles',
+          label: 'English',
+          language: 'en',
+          mode: 'showing'
+        },
+        active_track_source: { ends_with: 'subtitles/sintel-en.vtt' },
+        all_tracks_data: [
+          { 1 => { kind: 'subtitles', label: 'English', language: 'en', mode: 'showing' } },
+          { 2 => { kind: 'subtitles', label: 'Spanish', language: 'es', mode: 'disabled' } },
+          { 3 => { kind: 'subtitles', label: 'German', language: 'de', mode: 'disabled' } }
+        ]
       },
       audio_player => {
         visible: true,
@@ -63,7 +100,8 @@ class MediaTestPage < BaseTestPage
         muted: false,
         volume: 1,
         preload: preload,
-        src: ''
+        src: '',
+        track_count: 0
       }
     }
     verify_ui_states(ui)

--- a/lib/testcentricity_web/version.rb
+++ b/lib/testcentricity_web/version.rb
@@ -1,3 +1,3 @@
 module TestCentricityWeb
-  VERSION = '4.2.0'
+  VERSION = '4.2.1'
 end

--- a/lib/testcentricity_web/web_core/page_objects_helper.rb
+++ b/lib/testcentricity_web/web_core/page_objects_helper.rb
@@ -139,6 +139,16 @@ module TestCentricity
                      ui_object.ready_state
                    when :volume
                      ui_object.volume
+                   when :track_count
+                     ui_object.track_count
+                   when :active_track
+                     ui_object.active_track
+                   when :active_track_data
+                     ui_object.active_track_data
+                   when :active_track_source
+                     ui_object.active_track_source
+                   when :all_tracks_data
+                     ui_object.all_tracks_data
                    when :crossorigin
                      ui_object.crossorigin
                    when :preload

--- a/test_site/media_page.html
+++ b/test_site/media_page.html
@@ -56,27 +56,27 @@
                 <tbody>
                     <tr>
                         <td>
-                            <label id="video1">Video:</label>
+                            <h3 id="video1">Video:</h3>
                             <video id="video_player1" width="480" height="360" controls>
                                 <source src="media/count_and_bars.mp4" type="video/mp4">
                             </video>
                         </td>
-                    </tr>
-                    <tr>
                         <td>
-                            <label id="audio">Audio:</label>
-                            <audio id="audio_player" controls>
-                                <source src="media/bbc_scotland_report.mp3" type="audio/mp3">
-                            </audio>
+                            <h3 id="video2">Video with Captions:</h3>
+                            <video id="video_player2" width="520" controls>
+                                <source src="media/sintel-short.mp4" type="video/mp4">
+                                <track src="subtitles/sintel-en.vtt" kind="subtitles" srclang="en" label="English" default>
+                                <track src="subtitles/sintel-es.vtt" kind="subtitles" srclang="es" label="Spanish">
+                                <track src="subtitles/sintel-de.vtt" kind="subtitles" srclang="de" label="German">
+                            </video>
                         </td>
                     </tr>
                     <tr>
                         <td>
-                            <label id="video2">Video with Captions:</label>
-                            <video id="video_player2" width="400" controls>
-                                <source src="media/MIB2.mp4" type="video/mp4">
-                                <track src="media/MIB2-subtitles-pt-BR.vtt" kind="subtitles" srclang="pt" label="Portuguese" default>
-                            </video>
+                            <h3 id="audio">Audio:</h3>
+                            <audio id="audio_player" controls>
+                                <source src="media/bbc_scotland_report.mp3" type="audio/mp3">
+                            </audio>
                         </td>
                     </tr>
                 </tbody>

--- a/test_site/subtitles/sintel-de.vtt
+++ b/test_site/subtitles/sintel-de.vtt
@@ -1,0 +1,65 @@
+WEBVTT
+
+0
+00:00:00.000 --> 00:00:12.000
+<v Test>[Test]</v>
+
+1
+00:00:18.700 --> 00:00:21.500
+Diese Klinge birgt eine finstere
+Vergangenheit.
+
+2
+00:00:22.800 --> 00:00:26.800
+Durch sie wurde viel unschuldiges Blut
+vergossen.
+
+3
+00:00:29.000 --> 00:00:32.450
+Es ist töricht, so ganz allein und
+unvorbereitet zu reisen!
+
+4
+00:00:32.750 --> 00:00:35.800
+Du kannst von Glück sagen, dass dein
+Blut noch in deinen Adern fließt.
+
+5
+00:00:36.250 --> 00:00:37.300
+Danke.
+
+6
+00:00:38.500 --> 00:00:40.000
+Also...
+
+7
+00:00:40.400 --> 00:00:44.800
+...was führt dich in die Lande der
+Torwaechter?
+
+8
+00:00:46.000 --> 00:00:48.500
+Ich suche jemanden.
+
+9
+00:00:49.000 --> 00:00:53.200
+Ein teurer Freund?
+Eine verwandte Seele?
+
+10
+00:00:54.400 --> 00:00:56.000
+Ein Drache.
+
+11
+00:00:58.850 --> 00:01:01.750
+Ein gefährliches Unterfangen für eine
+einsame Jägerin.
+
+12
+00:01:02.950 --> 00:01:05.870
+Ich bin einsam, solange ich mich
+erinnern kann.
+
+13
+00:01:58.250 --> 00:01:59.500
+Wir sind fast fertig. Ruhig...

--- a/test_site/subtitles/sintel-en.vtt
+++ b/test_site/subtitles/sintel-en.vtt
@@ -1,0 +1,63 @@
+WEBVTT
+
+0
+00:00:00.000 --> 00:00:12.000
+<v Test>[Test]</v>
+
+NOTE This is a comment and must be preceded by a blank line
+
+1
+00:00:18.700 --> 00:00:21.500
+This blade has a dark past.
+
+2
+00:00:22.800 --> 00:00:26.800
+It has shed much innocent blood.
+
+3
+00:00:29.000 --> 00:00:32.450
+You're a fool for traveling alone,
+so completely unprepared.
+
+4
+00:00:32.750 --> 00:00:35.800
+You're lucky your blood's still flowing.
+
+5
+00:00:36.250 --> 00:00:37.300
+Thank you.
+
+6
+00:00:38.500 --> 00:00:40.000
+So...
+
+7
+00:00:40.400 --> 00:00:44.800
+What brings you to
+the land of the gatekeepers?
+
+8
+00:00:46.000 --> 00:00:48.500
+I'm searching for someone.
+
+9
+00:00:49.000 --> 00:00:53.200
+Someone very dear?
+A kindred spirit?
+
+10
+00:00:54.400 --> 00:00:56.000
+A dragon.
+
+11
+00:00:58.850 --> 00:01:01.750
+A dangerous quest for a lone hunter.
+
+12
+00:01:02.950 --> 00:01:05.870
+I've been alone for
+as long as I can remember.
+
+13
+00:01:58.250 --> 00:01:59.500
+We're almost done. Shhh...

--- a/test_site/subtitles/sintel-es.vtt
+++ b/test_site/subtitles/sintel-es.vtt
@@ -1,0 +1,63 @@
+WEBVTT
+
+0
+00:00:00.000 --> 00:00:12.000
+<v Test>[Test]</v>
+
+1
+00:00:18.700 --> 00:00:21.500
+Esta hoja tiene un pasado oscuro.
+
+2
+00:00:22.800 --> 00:00:26.800
+Ha derramado mucha sangre inocente.
+
+3
+00:00:29.000 --> 00:00:32.450
+Eres una tonta por viajar sola,
+sin ninguna preparación.
+
+4
+00:00:32.750 --> 00:00:35.800
+Tienes suerte de que aún
+corra sangre por tus venas.
+
+5
+00:00:36.250 --> 00:00:37.300
+Gracias.
+
+6
+00:00:38.500 --> 00:00:40.000
+Entonces...
+
+7
+00:00:40.400 --> 00:00:44.800
+Qué te trae a la tierra
+de los guardianes?
+
+8
+00:00:46.000 --> 00:00:48.500
+Estoy buscando a alguien.
+
+9
+00:00:49.000 --> 00:00:53.200
+Alguien muy querido?
+Un alma gemela?
+
+10
+00:00:54.400 --> 00:00:56.000
+Un dragón.
+
+11
+00:00:58.850 --> 00:01:01.750
+Una aventura peligrosa
+para una cazadora solitaria.
+
+12
+00:01:02.950 --> 00:01:05.870
+He estado sola desde
+que tengo memoria.
+
+13
+00:01:58.250 --> 00:01:59.500
+Ya casi terminamos. Shhh...


### PR DESCRIPTION
* Added Media.track_count, active_track, active_track_data, all_tracks_data, track_data, active_track_source, and track_source methods.
* Updated BasePageSectionObject.verify_ui_states method to support verification of the :track_count, :active_track, :active_track_data, :all_tracks_data, :track_data, :active_track_source, and :track_source Media properties.
*Added test media with multiple language subtitles .vtt files for test site Media Page tests.
* Updated cukes to verify new Media methods.