### PR TITLE
initialize_web_driver missing Downloads folder exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 
 
+## [4.2.5] - 10-JUNE-2022
+
+### Fixed
+*`WebDriverConnect.initialize_web_driver` method no longer raises `No such file or directory @ dir_s_mkdir` error due to
+missing `Downloads` folder when running tests in parallel.
+
+
 ## [4.2.4] - 02-JUNE-2022
 
 ### Added

--- a/lib/testcentricity_web/version.rb
+++ b/lib/testcentricity_web/version.rb
@@ -1,3 +1,3 @@
 module TestCentricityWeb
-  VERSION = '4.2.4'
+  VERSION = '4.2.5'
 end

--- a/lib/testcentricity_web/web_core/webdriver_helper.rb
+++ b/lib/testcentricity_web/web_core/webdriver_helper.rb
@@ -32,8 +32,10 @@ module TestCentricity
         # :nocov:
         Environ.parallel = true
         Environ.process_num = ENV['TEST_ENV_NUMBER']
-        @downloads_path = "#{@downloads_path}/#{ENV['TEST_ENV_NUMBER']}"
-        Dir.mkdir(@downloads_path) unless Dir.exist?(@downloads_path)
+        if Dir.exist?(@downloads_path)
+          @downloads_path = "#{@downloads_path}/#{ENV['TEST_ENV_NUMBER']}"
+          Dir.mkdir(@downloads_path) unless Dir.exist?(@downloads_path)
+        end
         # :nocov:
       else
         Environ.parallel = false


### PR DESCRIPTION
* `WebDriverConnect.initialize_web_driver` method no longer raises `No such file or directory @ dir_s_mkdir` error due to missing `Downloads` folder when running tests in parallel.