### PR TITLE
Fix gemspec to no longer include specs and cukes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 
 
+## [4.2.6] - 12-JUNE-2022
+
+### Fixed
+* Fix `gemspec` to no longer include specs and cuke tests as part of deployment package for gem.
+
+
 ## [4.2.5] - 10-JUNE-2022
 
 ### Fixed

--- a/lib/testcentricity_web/version.rb
+++ b/lib/testcentricity_web/version.rb
@@ -1,3 +1,3 @@
 module TestCentricityWeb
-  VERSION = '4.2.5'
+  VERSION = '4.2.6'
 end

--- a/testcentricity_web.gemspec
+++ b/testcentricity_web.gemspec
@@ -28,9 +28,7 @@ Gem::Specification.new do |spec|
     'documentation_uri' => 'https://www.rubydoc.info/gems/testcentricity_web'
   }
 
-  spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.files         = Dir.glob('lib/**/*') + %w[README.md CHANGELOG.md LICENSE.txt .yardopts]
   spec.require_paths = ['lib']
   spec.requirements  << 'Capybara, Selenium-WebDriver'
 


### PR DESCRIPTION
Fix gemspec to no longer include specs and cuke tests as part of deployment package for gem.