### PR TITLE
User-defined browser options for unsupported cloud hosting services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 
 
+## [4.4.2] - 22-DEC-2023
+
+### Added
+* Added support for specifying and connecting to web browsers on unsupported cloud hosting services using `custom` user-
+defined driver and capabilities.
+
+
 ## [4.4.0] - 22-DEC-2023
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2739,6 +2739,70 @@ test configuration options.
     WebDriverConnect.initialize_web_driver(options)
 
 
+#### Remote Browsers on Unsupported Cloud Hosting Services
+
+Limited support is provided for executing automated tests against remotely hosted desktop and mobile web browsers on currently
+unsupported cloud hosting services. You must call the `TestCentricity::WebDriverConnect.initialize_web_driver` method with
+an `options` hash - Environment Variables cannot be used to specify a user-defined custom WebDriver instance.
+
+The following options and capabilities must be specified:
+- `driver:` must be set to `:custom`
+- `endpoint:` must be set to the endpoint URL configuration specified by the hosting service
+- `browserName:` in the `capabilities:` hash must be set to name from capability specified by the hosting service
+
+All other required capabilities specified by the hosting service configuration documentation should be included in the
+`capabilities:` hash.
+
+    options = {
+      driver: :custom,
+      endpoint: endpoint_url,
+      capabilities: { browserName: browser_name_from_chart }
+    }
+    WebDriverConnect.initialize_web_driver(options)
+
+ℹ️ If an optional user defined `driver_name:` is not specified in the `options` hash, the default driver name will be set to
+`:custom_<browserName>` - e.g. `:custom_chrome` or `:custom_safari`.
+
+Prior to calling the `TestCentricity::WebDriverConnect.initialize_web_driver` method, you must set `Environ.platform` to
+either `:desktop` or `:mobile`, and `Environ.device` to either `:web` or `:device` dependent on whether the target browser
+is a desktop browser or a mobile browser running on a mobile device or simulator.
+
+Below is an example for specifying a connection to a Firefox desktop web browser on an unsupported hosting service:
+
+      Environ.platform = :desktop
+      Environ.device = :web
+      options = {
+        driver: :custom,
+        driver_name: :user_defined,
+        browser_size: [1400, 1100],
+        endpoint: endpoint_url,
+        capabilities: {
+          browserName: 'Firefox',
+          browser_version: browser_version_from_chart
+          #  other capabilities go here
+        }
+      }
+      WebDriverConnect.initialize_web_driver(options)
+
+Below is an example for specifying a connection to a mobile Safari web browser running on an iPad on an unsupported hosting
+service:
+
+      Environ.platform = :mobile
+      Environ.device = :device
+      Environ.device_name = device_name_from_chart
+      options = {
+        driver: :custom,
+        driver_name: :user_defined,
+        device_type: :tablet,
+        endpoint: endpoint_url,
+        capabilities: {
+          browserName: 'Safari',
+          #  other capabilities go here
+        }
+      }
+      WebDriverConnect.initialize_web_driver(options)
+
+
 ### Closing Browser and Driver Instances
 
 #### Closing Instances Using Cucumber

--- a/README.md
+++ b/README.md
@@ -2769,8 +2769,10 @@ is a desktop browser or a mobile browser running on a mobile device or simulator
 
 Below is an example for specifying a connection to a Firefox desktop web browser on an unsupported hosting service:
 
+      # specify desktop platform
       Environ.platform = :desktop
       Environ.device = :web
+      # instantiate a cloud hosted desktop web browser on an unsupported hosting service
       options = {
         driver: :custom,
         driver_name: :user_defined,
@@ -2787,9 +2789,11 @@ Below is an example for specifying a connection to a Firefox desktop web browser
 Below is an example for specifying a connection to a mobile Safari web browser running on an iPad on an unsupported hosting
 service:
 
+      # specify mobile platform, device type, and device name
       Environ.platform = :mobile
       Environ.device = :device
       Environ.device_name = device_name_from_chart
+      # instantiate a cloud hosted mobile browser on a device on an unsupported hosting service
       options = {
         driver: :custom,
         driver_name: :user_defined,

--- a/Rakefile
+++ b/Rakefile
@@ -171,6 +171,7 @@ end
 
 desc 'Build and release new version of gem'
 task :release do
+  ENV['COVERAGE'] = 'false'
   version = TestCentricityWeb::VERSION
   puts "Release version #{version} of TestCentricity Web gem, y/n?"
   exit(1) unless $stdin.gets.chomp == 'y'

--- a/Rakefile
+++ b/Rakefile
@@ -52,6 +52,12 @@ RSpec::Core::RakeTask.new(:saucelabs_specs) do |t|
 end
 
 
+desc 'Run Custom User-defined WebDriver specs'
+RSpec::Core::RakeTask.new(:custom_webdriver_specs) do |t|
+  t.rspec_opts = '--tag custom'
+end
+
+
 desc 'Run Multiple Driver specs'
 RSpec::Core::RakeTask.new(:multi_driver_spec) do |t|
   t.rspec_opts = '--tag multi_driver_spec'
@@ -151,6 +157,7 @@ task all: [:required,
            :safari_local,
            :docker_grid_specs,
            :browserstack_specs,
+           :custom_webdriver_specs,
            :multi_driver_spec,
            :mobile]
 

--- a/lib/testcentricity_web/version.rb
+++ b/lib/testcentricity_web/version.rb
@@ -1,3 +1,3 @@
 module TestCentricityWeb
-  VERSION = '4.4.1'
+  VERSION = '4.4.2'
 end

--- a/spec/testcentricity_web/webdriver_connect/custom_webdriver_spec.rb
+++ b/spec/testcentricity_web/webdriver_connect/custom_webdriver_spec.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+RSpec.describe TestCentricity::WebDriverConnect, custom: true do
+  include_context 'test_site'
+
+  before(:context) do
+    # load cloud services credentials into environment variables
+    load_cloud_credentials
+  end
+
+  context 'Connect to user-defined web browsers using W3C desired_capabilities hash' do
+    it 'raises exception when no capabilities are defined' do
+      options = {
+        driver: :custom,
+        driver_name: :custom_no_caps,
+        endpoint: "https://#{ENV['TB_USERNAME']}:#{ENV['TB_AUTHKEY']}@hub.testingbot.com/wd/hub",
+      }
+      expect { WebDriverConnect.initialize_web_driver(options) }.to raise_error('User-defined webdriver requires that you provide capabilities')
+    end
+
+    it 'raises exception when no endpoint is defined' do
+      options = {
+        driver: :custom,
+        driver_name: :custom_no_endpoint,
+        browser_size: [1400, 1100],
+        capabilities: {
+          browserName: 'microsoftedge',
+          browser_version: 'latest',
+          platform_name: 'MONTEREY',
+          'tb:options': {
+            name: 'TestCentricity Web - Custom WebDriver',
+            build: "Version #{TestCentricityWeb::VERSION}",
+            'screen-resolution': '2048x1536',
+            'selenium-version': '4.14.1'
+          }
+        }
+      }
+      expect { WebDriverConnect.initialize_web_driver(options) }.to raise_error('User-defined webdriver requires that you provide an endpoint')
+    end
+
+    it 'connects to an Edge desktop browser on TestingBot' do
+      Environ.platform = :desktop
+      Environ.device = :web
+      options = {
+        driver: :custom,
+        browser_size: [1400, 1100],
+        endpoint: "https://#{ENV['TB_USERNAME']}:#{ENV['TB_AUTHKEY']}@hub.testingbot.com/wd/hub",
+        capabilities: {
+          browserName: 'microsoftedge',
+          browser_version: 'latest',
+          platform_name: 'MONTEREY',
+          'tb:options': {
+            name: 'TestCentricity Web - Custom WebDriver',
+            build: "Version #{TestCentricityWeb::VERSION}",
+            'screen-resolution': '2048x1536',
+            'selenium-version': '4.14.1'
+          }
+        }
+      }
+      WebDriverConnect.initialize_web_driver(options)
+      verify_custom_browser(browser = :microsoftedge, platform = :desktop)
+    end
+
+    it 'connects to a Safari desktop browser on BrowserStack' do
+      Environ.platform = :desktop
+      Environ.device = :web
+      options = {
+        driver: :custom,
+        driver_name: :custom_browserstack,
+        browser_size: [1400, 1100],
+        endpoint: "https://#{ENV['BS_USERNAME']}:#{ENV['BS_AUTHKEY']}@hub-cloud.browserstack.com/wd/hub",
+        capabilities: {
+          browserName: 'Safari',
+          browser_version: 'latest',
+          'bstack:options': {
+            userName: ENV['BS_USERNAME'],
+            accessKey: ENV['BS_AUTHKEY'],
+            projectName: 'TestCentricity Web - Custom WebDriver',
+            buildName: "Version #{TestCentricityWeb::VERSION}",
+            sessionName: 'RSpec - Custom WebDriver',
+            os: 'OS X',
+            osVersion: 'Sonoma',
+            resolution: '3840x2160',
+            seleniumVersion: '4.15.0'
+          }
+        }
+      }
+      WebDriverConnect.initialize_web_driver(options)
+      verify_custom_browser(browser = :safari, platform = :desktop)
+    end
+
+    it 'connects to a Safari mobile browser on BrowserStack' do
+      Environ.platform = :mobile
+      Environ.device = :device
+      Environ.device_name = 'iPad Pro 12.9 2018'
+      options = {
+        driver: :custom,
+        driver_name: :custom_bs_mobile,
+        device_type: :tablet,
+        endpoint: "https://#{ENV['BS_USERNAME']}:#{ENV['BS_AUTHKEY']}@hub-cloud.browserstack.com/wd/hub",
+        capabilities: {
+          browserName: 'Safari',
+          'bstack:options': {
+            userName: ENV['BS_USERNAME'],
+            accessKey: ENV['BS_AUTHKEY'],
+            projectName: 'TestCentricity Web - Custom WebDriver',
+            buildName: "Version #{TestCentricityWeb::VERSION}",
+            sessionName: 'RSpec - Custom WebDriver',
+            os: 'ios',
+            osVersion: '15',
+            deviceName: Environ.device_name,
+            appiumVersion: '1.22.0',
+            realMobile: 'true'
+          }
+        }
+      }
+      WebDriverConnect.initialize_web_driver(options)
+      verify_custom_browser(browser = :safari, platform = :mobile, device = 'iPad Pro 12.9 2018')
+    end
+  end
+
+  after(:each) do
+    WebDriverConnect.close_all_drivers
+  end
+
+
+  def verify_custom_browser(browser, platform, device = nil)
+    # load Apple web site
+    Capybara.page.driver.browser.navigate.to(test_site_url)
+    Capybara.page.find(:css, test_site_locator, wait: 10, visible: true)
+    # verify Environs are correctly set
+    expect(Environ.browser).to eq(browser)
+    expect(Environ.platform).to eq(platform)
+    expect(Environ.session_state).to eq(:running)
+    expect(Environ.driver).to eq(:custom)
+    expect(Environ.grid).to eq(:custom)
+    if device
+      expect(Environ.device_name).to eq(device)
+      expect(Environ.device).to eq(:device)
+      expect(Environ.device_type).to eq(:tablet)
+      expect(Environ.is_device?).to eq(true)
+      expect(Environ.is_web?).to eq(false)
+    else
+      expect(Environ.device).to eq(:web)
+      expect(Environ.is_web?).to eq(true)
+      expect(Environ.is_device?).to eq(false)
+    end
+    expect(Capybara.current_driver).to eq(Environ.driver_name)
+  end
+end

--- a/spec/testcentricity_web/webdriver_connect/local_webdriver_spec.rb
+++ b/spec/testcentricity_web/webdriver_connect/local_webdriver_spec.rb
@@ -5,6 +5,22 @@ RSpec.describe TestCentricity::WebDriverConnect, required: true do
 
   context 'Connect to locally hosted desktop web browsers using W3C desired_capabilities hash' do
     context 'local web browser instances' do
+      it 'raises exception when no capabilities defined' do
+        caps = {
+          capabilities: { browserName: :firefox },
+          driver: :invalid_driver
+        }
+        expect { WebDriverConnect.initialize_web_driver(caps) }.to raise_error('invalid_driver is not a supported driver')
+      end
+
+      it 'raises exception when no :browserName is specified' do
+        caps = {
+          capabilities: { orientation: :portrait },
+          driver: :webdriver
+        }
+        expect { WebDriverConnect.initialize_web_driver(caps) }.to raise_error('Missing :browserName in @capabilities')
+      end
+
       it 'connects to a local Firefox browser' do
         caps = {
           capabilities: { browserName: :firefox },

--- a/spec/testcentricity_web/webdriver_connect/multi_driver_spec.rb
+++ b/spec/testcentricity_web/webdriver_connect/multi_driver_spec.rb
@@ -11,6 +11,18 @@ RSpec.describe TestCentricity::WebDriverConnect, multi_driver_spec: true do
   end
 
   context 'Connect to multiple locally hosted desktop and mobile web browsers' do
+    it 'raises exception when named driver cannot be found' do
+      # instantiate a locally hosted desktop Chrome browser
+      caps = {
+        capabilities: { browserName: :chrome },
+        driver_name: :my_chrome,
+        driver: :webdriver,
+        browser_size: [1100, 900]
+      }
+      WebDriverConnect.initialize_web_driver(caps)
+      expect {  WebDriverConnect.activate_driver(:emulated_iphone) }.to raise_error("Could not find a driver named 'emulated_iphone'")
+    end
+
     it 'connects to multiple desktop and emulated mobile browsers' do
       # instantiate a locally hosted emulated iPad browser
       caps = {

--- a/testcentricity_web.gemspec
+++ b/testcentricity_web.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
     'changelog_uri' => 'https://github.com/TestCentricity/testcentricity_web/blob/main/CHANGELOG.md',
     'bug_tracker_uri' => 'https://github.com/TestCentricity/testcentricity_web/issues',
     'wiki_uri' => 'https://github.com/TestCentricity/testcentricity_web/wiki',
-    'documentation_uri' => 'https://www.rubydoc.info/gems/testcentricity_web/4.4.1'
+    'documentation_uri' => 'https://www.rubydoc.info/gems/testcentricity_web'
   }
 
   spec.files         = Dir.glob('lib/**/*') + %w[README.md CHANGELOG.md LICENSE.md .yardopts]


### PR DESCRIPTION
## Proposed changes

Added support for specifying and connecting to web browsers on unsupported cloud hosting services using custom user-defined driver and capabilities.

## Types of changes

What types of changes does your code introduce to TestCentricity Web?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask.

- [x] I have added tests (specs and/or Cucumber tests) that prove my fix is effective or that my feature works
- [x] Specs and/or Cucumber tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
