### PR TITLE
Use SL_DATA_CENTER environ variable for Sauce Labs endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 All notable changes to this project will be documented in this file.
 
 
-## [4.4.2] - 22-DEC-2023
+## [4.4.3] - 24-DEC-2023
+
+### Changed
+* Changed Sauce Labs `DATA_CENTER` Environment Variable to `SL_DATA_CENTER`.
+
+
+## [4.4.2] - 23-DEC-2023
 
 ### Added
 * Added support for specifying and connecting to web browsers on unsupported cloud hosting services using `custom` user-

--- a/README.md
+++ b/README.md
@@ -2327,7 +2327,7 @@ the following **Environment Variables** must be set as described in the table be
 | `DRIVER`                 | Must be set to `saucelabs`                                                                                                 |
 | `SL_USERNAME`            | Must be set to your Sauce Labs account user name or email address                                                          |
 | `SL_AUTHKEY`             | Must be set to your Sauce Labs account access key                                                                          |
-| `DATA_CENTER`            | Must be set to your Sauce Labs account Data Center assignment (`us-west-1`, `eu-central-1`, `apac-southeast-1`)            |
+| `SL_DATA_CENTER`         | Must be set to your Sauce Labs account Data Center assignment (`us-west-1`, `eu-central-1`, `apac-southeast-1`)            |
 | `SL_OS`                  | Refer to `platformName` capability in the Config Script section of the Platform Configurator page                          |
 | `SL_BROWSER`             | Must be set to `chrome`, `firefox`, `safari`, `internetExplorer`, or `MicrosoftEdge`                                       |
 | `SL_VERSION`             | Refer to `browserVersion` capability in the Config Script section of the Platform Configurator page                        |
@@ -2363,11 +2363,11 @@ When using the `options` hash, the following options and capabilities must be sp
 
 ℹ️ If an `endpoint:` is not specified in the `options` hash, then the default remote endpoint URL will be set to the following:
 
-`https://#{ENV['SL_USERNAME']}:#{ENV['SL_AUTHKEY']}@ondemand.#{ENV['DATA_CENTER']}.saucelabs.com:443/wd/hub`
+`https://#{ENV['SL_USERNAME']}:#{ENV['SL_AUTHKEY']}@ondemand.#{ENV['SL_DATA_CENTER']}.saucelabs.com:443/wd/hub`
 
 This default endpoint requires that the `SL_USERNAME` Environment Variable is set to your Sauce Labs account user name, the
-`SL_AUTHKEY` Environment Variable is set to your Sauce Labs access key, and the `DATA_CENTER` Environment Variable is set to
-your Sauce Labs account Data Center assignment (`us-west-1`, `eu-central-1`, `apac-southeast-1`).
+`SL_AUTHKEY` Environment Variable is set to your Sauce Labs access key, and the `SL_DATA_CENTER` Environment Variable is
+set to your Sauce Labs account Data Center assignment (`us-west-1`, `eu-central-1`, `apac-southeast-1`).
 
 Below is an example of an `options` hash for specifying a connection to the latest version of an Edge desktop web browser
 running on macOS Ventura hosted on Sauce Labs. The `options` hash includes options for specifying the driver name, setting
@@ -2418,7 +2418,7 @@ the following **Environment Variables** must be set as described in the table be
 | `DEVICE_TYPE`            | Must be set to `phone` or `tablet`                                                                              |
 | `SL_USERNAME`            | Must be set to your Sauce Labs account user name or email address                                               |
 | `SL_AUTHKEY`             | Must be set to your Sauce Labs account access key                                                               |
-| `DATA_CENTER`            | Must be set to your Sauce Labs account Data Center assignment (`us-west-1`, `eu-central-1`, `apac-southeast-1`) |
+| `SL_DATA_CENTER`         | Must be set to your Sauce Labs account Data Center assignment (`us-west-1`, `eu-central-1`, `apac-southeast-1`) |
 | `ORIENTATION`            | [Optional] Set to `PORTRAIT` or `LANDSCAPE`                                                                     |
 
 
@@ -2456,11 +2456,11 @@ When using the `options` hash, the following options and capabilities must be sp
 
 ℹ️ If an `endpoint:` is not specified in the `options` hash, then the default remote endpoint URL will be set to the following:
 
-`https://#{ENV['SL_USERNAME']}:#{ENV['SL_AUTHKEY']}@ondemand.#{ENV['DATA_CENTER']}.saucelabs.com:443/wd/hub`
+`https://#{ENV['SL_USERNAME']}:#{ENV['SL_AUTHKEY']}@ondemand.#{ENV['SL_DATA_CENTER']}.saucelabs.com:443/wd/hub`
 
 This default endpoint requires that the `SL_USERNAME` Environment Variable is set to your Sauce Labs account user name, the
-`SL_AUTHKEY` Environment Variable is set to your Sauce Labs access key, and the `DATA_CENTER` Environment Variable is set to
-your Sauce Labs account Data Center assignment (`us-west-1`, `eu-central-1`, `apac-southeast-1`).
+`SL_AUTHKEY` Environment Variable is set to your Sauce Labs access key, and the `SL_DATA_CENTER` Environment Variable is
+set to your Sauce Labs account Data Center assignment (`us-west-1`, `eu-central-1`, `apac-southeast-1`).
 
 Below is an example of an `options` hash for specifying a connection to a mobile Safari web browser running on an iPad
 tablet hosted on Sauce Labs. The `options` hash includes options for specifying the driver name, and capabilities for setting
@@ -2993,7 +2993,7 @@ with access to your version control system.
     #          access to your version control system
     #==============
 
-    saucelabs:  DRIVER=saucelabs SL_USERNAME="<INSERT USER NAME HERE>" SL_AUTHKEY="<INSERT PASSWORD HERE>" DATA_CENTER="<INSERT DATA CENTER HERE"
+    saucelabs:  DRIVER=saucelabs SL_USERNAME="<INSERT USER NAME HERE>" SL_AUTHKEY="<INSERT PASSWORD HERE>" SL_DATA_CENTER="<INSERT DATA CENTER HERE"
     sl_desktop: --profile saucelabs <%= desktop %>
     sl_mobile:  --profile saucelabs <%= mobile %>
 

--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -153,7 +153,7 @@ tb_edge_monterey:   --profile tb_macos_monterey TB_BROWSER="microsoftedge" TB_VE
 # profiles for remotely hosted web browsers on the SauceLabs service
 #==============
 
-saucelabs:  DRIVER=saucelabs DATA_CENTER="us-west-1" AUTOMATE_PROJECT="TestCentricity Web - SauceLabs"
+saucelabs:  DRIVER=saucelabs SL_DATA_CENTER="us-west-1" AUTOMATE_PROJECT="TestCentricity Web - SauceLabs"
 sl_desktop: --profile saucelabs <%= desktop %>
 sl_mobile:  --profile saucelabs <%= mobile %>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   chrome:
-    image: selenium/node-chrome:4.16.1-20231208
+    image: selenium/node-chrome:4.15.0-20231129
     shm_size: 2gb
     depends_on:
       - selenium-hub
@@ -18,7 +18,7 @@ services:
       - ./downloads:/home/seluser/Downloads
 
   edge:
-    image: selenium/node-edge:4.16.1-20231208
+    image: selenium/node-edge:4.15.0-20231129
     shm_size: 2gb
     depends_on:
       - selenium-hub
@@ -32,7 +32,7 @@ services:
       - ./downloads:/home/seluser/Downloads
 
   firefox:
-    image: selenium/node-firefox:4.16.1-20231208
+    image: selenium/node-firefox:4.15.0-20231129
     shm_size: 2gb
     depends_on:
       - selenium-hub
@@ -46,7 +46,7 @@ services:
       - ./downloads:/home/seluser/Downloads
 
   selenium-hub:
-    image: selenium/hub:4.16.1-20231208
+    image: selenium/hub:4.15.0-20231129
     container_name: selenium-hub
     ports:
       - "4442:4442"

--- a/features/support/cloud_credentials.rb
+++ b/features/support/cloud_credentials.rb
@@ -7,6 +7,7 @@ def load_cloud_credentials
   # load Sauce Labs credentials into associated environment variables
   ENV['SL_USERNAME'] = cloud_creds['saucelabs']['SL_USERNAME']
   ENV['SL_AUTHKEY'] = cloud_creds['saucelabs']['SL_AUTHKEY']
+  ENV['SL_DATA_CENTER'] = cloud_creds['saucelabs']['SL_DATA_CENTER']
   # load TestingBot credentials into associated environment variables
   ENV['TB_USERNAME'] = cloud_creds['testingbot']['TB_USERNAME']
   ENV['TB_AUTHKEY'] = cloud_creds['testingbot']['TB_AUTHKEY']

--- a/lib/testcentricity_web/version.rb
+++ b/lib/testcentricity_web/version.rb
@@ -1,3 +1,3 @@
 module TestCentricityWeb
-  VERSION = '4.4.2'
+  VERSION = '4.4.3'
 end

--- a/lib/testcentricity_web/web_core/webdriver_helper.rb
+++ b/lib/testcentricity_web/web_core/webdriver_helper.rb
@@ -582,7 +582,7 @@ module TestCentricity
       end
       # specify endpoint url
       if @endpoint.nil?
-        @endpoint = "https://#{ENV['SL_USERNAME']}:#{ENV['SL_AUTHKEY']}@ondemand.#{ENV['DATA_CENTER']}.saucelabs.com:443/wd/hub"
+        @endpoint = "https://#{ENV['SL_USERNAME']}:#{ENV['SL_AUTHKEY']}@ondemand.#{ENV['SL_DATA_CENTER']}.saucelabs.com:443/wd/hub"
       end
       # define SauceLab options
       options = if @capabilities.nil?

--- a/spec/support/shared_contexts/cloud_creds_context.rb
+++ b/spec/support/shared_contexts/cloud_creds_context.rb
@@ -8,6 +8,7 @@ RSpec.shared_context 'cloud_credentials' do
     # load Sauce Labs credentials into associated environment variables
     ENV['SL_USERNAME'] = @cloud_creds['saucelabs']['SL_USERNAME']
     ENV['SL_AUTHKEY'] = @cloud_creds['saucelabs']['SL_AUTHKEY']
+    ENV['SL_DATA_CENTER'] = @cloud_creds['saucelabs']['SL_DATA_CENTER']
     # load TestingBot credentials into associated environment variables
     ENV['TB_USERNAME'] = @cloud_creds['testingbot']['TB_USERNAME']
     ENV['TB_AUTHKEY'] = @cloud_creds['testingbot']['TB_AUTHKEY']

--- a/spec/testcentricity_web/webdriver_connect/browserstack_spec.rb
+++ b/spec/testcentricity_web/webdriver_connect/browserstack_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe TestCentricity::WebDriverConnect, browserstack: true do
             os: ENV['BS_OS'],
             osVersion: ENV['BS_OS_VERSION'],
             resolution: ENV['RESOLUTION'],
-            seleniumVersion: '4.7.2'
+            seleniumVersion: '4.15.0'
           }
         }
       }
@@ -61,7 +61,7 @@ RSpec.describe TestCentricity::WebDriverConnect, browserstack: true do
             os: ENV['BS_OS'],
             osVersion: ENV['BS_OS_VERSION'],
             resolution: ENV['RESOLUTION'],
-            seleniumVersion: '4.7.2'
+            seleniumVersion: '4.15.0'
           }
         }
       }
@@ -83,7 +83,7 @@ RSpec.describe TestCentricity::WebDriverConnect, browserstack: true do
             os: ENV['BS_OS'],
             osVersion: ENV['BS_OS_VERSION'],
             resolution: ENV['RESOLUTION'],
-            seleniumVersion: '4.7.2'
+            seleniumVersion: '4.15.0'
           }
         }
       }
@@ -104,7 +104,7 @@ RSpec.describe TestCentricity::WebDriverConnect, browserstack: true do
             os: ENV['BS_OS'],
             osVersion: ENV['BS_OS_VERSION'],
             resolution: ENV['RESOLUTION'],
-            seleniumVersion: '4.7.2'
+            seleniumVersion: '4.15.0'
           }
         }
       }
@@ -208,7 +208,7 @@ RSpec.describe TestCentricity::WebDriverConnect, browserstack: true do
             os: ENV['BS_OS'],
             osVersion: ENV['BS_OS_VERSION'],
             resolution: ENV['RESOLUTION'],
-            seleniumVersion: '4.15.0'
+            seleniumVersion: '4.14.1'
           }
         }
       }

--- a/spec/testcentricity_web/webdriver_connect/saucelabs_spec.rb
+++ b/spec/testcentricity_web/webdriver_connect/saucelabs_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe TestCentricity::WebDriverConnect, saucelabs: true do
     load_cloud_credentials
     # specify generic browser config environment variables
     ENV['DRIVER'] = 'saucelabs'
-    ENV['DATA_CENTER'] = 'us-west-1'
+    ENV['SL_DATA_CENTER'] = 'us-west-1'
     ENV['SL_VERSION'] = 'latest'
     ENV['SL_OS'] = 'macOS 13'
     ENV['AUTOMATE_PROJECT'] = 'TestCentricity Web - SauceLabs'
@@ -47,7 +47,7 @@ RSpec.describe TestCentricity::WebDriverConnect, saucelabs: true do
     let(:desktop_caps_hash) {
       {
         driver: :saucelabs,
-        endpoint: "https://#{ENV['SL_USERNAME']}:#{ENV['SL_AUTHKEY']}@ondemand.#{ENV['DATA_CENTER']}.saucelabs.com:443/wd/hub",
+        endpoint: "https://#{ENV['SL_USERNAME']}:#{ENV['SL_AUTHKEY']}@ondemand.#{ENV['SL_DATA_CENTER']}.saucelabs.com:443/wd/hub",
         browser_size: [1400, 1100],
         capabilities: {
           browserName: ENV['SL_BROWSER'],


### PR DESCRIPTION
## Proposed changes

* Use `SL_DATA_CENTER` environ variable for Sauce Labs endpoints to avoid potential conflicts with other Data Center designators for custom user-defined cloud hosted browser services.
* Ensure that correct LambdaTest Environment Variables are correctly associated with name, project, and build capabilities.
* Add `lambdatest` specs and rake task.
* User Selenium WebDriver version 4.15.x in BrowserStack specs and in `docker-compose.yml`.

## Types of changes

What types of changes does your code introduce to TestCentricity Web?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask.

- [x] I have added tests (specs and/or Cucumber tests) that prove my fix is effective or that my feature works
- [x] Specs and/or Cucumber tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules