### PR TITLE
Fix StaleElementReferenceError when testing with multiple WebDriver instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes to this project will be documented in this file.
 
 
+## [4.4.5] - 10-JAN-2024
+
+### Fixed
+* `UIElement.find_object` no longer raises `Selenium::WebDriver::Error::StaleElementReferenceError` when testing with
+multiple WebDriver instances.
+* `DataPresenter.initialize` no longer fails if `data` parameter is `nil`.
+
+
 ## [4.4.4] - 08-JAN-2024
 
 ### Fixed

--- a/lib/testcentricity_web/data_objects/data_objects_helper.rb
+++ b/lib/testcentricity_web/data_objects/data_objects_helper.rb
@@ -41,7 +41,7 @@ module TestCentricity
     attr_accessor :context
 
     def initialize(data)
-      self.attributes = data
+      self.attributes = data unless data.nil?
     end
 
     def self.current

--- a/lib/testcentricity_web/version.rb
+++ b/lib/testcentricity_web/version.rb
@@ -1,3 +1,3 @@
 module TestCentricityWeb
-  VERSION = '4.4.4'
+  VERSION = '4.4.5'
 end

--- a/lib/testcentricity_web/web_elements/ui_element.rb
+++ b/lib/testcentricity_web/web_elements/ui_element.rb
@@ -46,7 +46,7 @@ module TestCentricity
       attr_reader   :parent, :locator, :context, :type, :name
       attr_accessor :alt_locator, :locator_type, :original_style
       attr_accessor :base_object
-      attr_accessor :mru_object, :mru_locator, :mru_parent
+      attr_accessor :mru_object, :mru_locator, :mru_parent, :mru_driver
 
       XPATH_SELECTORS = ['//', '[@', '[contains(']
       CSS_SELECTORS   = %w[# :nth-child( :first-child :last-child :nth-of-type( :first-of-type :last-of-type ^= $= *= :contains(]
@@ -67,6 +67,7 @@ module TestCentricity
         @mru_object = nil
         @mru_locator = nil
         @mru_parent = nil
+        @mru_driver = nil
       end
 
       def set_locator_type(locator = nil)
@@ -1072,6 +1073,7 @@ module TestCentricity
       private
 
       def find_object(visible = true)
+        reset_mru_cache if @mru_driver != Environ.driver_name
         obj_locator = @alt_locator.nil? ? @locator : @alt_locator
         parent_section = @context == :section && !@parent.get_locator.nil?
         tries ||= parent_section ? 2 : 1
@@ -1102,6 +1104,7 @@ module TestCentricity
         @mru_object = obj
         @mru_locator = obj_locator
         @mru_parent = parent_locator
+        @mru_driver = Environ.driver_name
         [obj, @locator_type]
       rescue StandardError
         retry if (tries -= 1).positive?


### PR DESCRIPTION
* `UIElement.find_object` no longer raises `Selenium::WebDriver::Error::StaleElementReferenceError` when testing with multiple WebDriver instances.
* `DataPresenter.initialize` no longer fails if `data` parameter is `nil`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have added tests (specs and/or Cucumber tests) that prove my fix is effective or that my feature works
- [x] Specs and/or Cucumber tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules