### PR TITLE
WebDriverConnect.num_drivers fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 
 
+## [4.4.6] - 12-JAN-2024
+
+### Fixed
+* `WebDriverConnect.num_drivers` no longer raises exception if called before any WebDrivers have been instantiated.
+
+
 ## [4.4.5] - 10-JAN-2024
 
 ### Fixed

--- a/lib/testcentricity_web/version.rb
+++ b/lib/testcentricity_web/version.rb
@@ -1,3 +1,3 @@
 module TestCentricityWeb
-  VERSION = '4.4.5'
+  VERSION = '4.4.6'
 end

--- a/lib/testcentricity_web/web_core/webdriver_helper.rb
+++ b/lib/testcentricity_web/web_core/webdriver_helper.rb
@@ -122,7 +122,7 @@ module TestCentricity
     #
     # @return [Integer]
     def self.num_drivers
-      @drivers.length
+      @drivers.nil? ? 0 : @drivers.length
     end
 
     # Close all browsers and terminate all driver instances

--- a/spec/testcentricity_web/webdriver_connect/local_webdriver_spec.rb
+++ b/spec/testcentricity_web/webdriver_connect/local_webdriver_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe TestCentricity::WebDriverConnect, required: true do
 
   context 'Connect to locally hosted desktop web browsers using W3C desired_capabilities hash' do
     context 'local web browser instances' do
+      it 'num_drivers returns 0 when no WebDrivers have been instantiated' do
+        expect(WebDriverConnect.num_drivers).to eq(0)
+      end
+
       it 'raises exception when no capabilities defined' do
         caps = {
           capabilities: { browserName: :firefox },
@@ -28,6 +32,7 @@ RSpec.describe TestCentricity::WebDriverConnect, required: true do
         }
         WebDriverConnect.initialize_web_driver(caps)
         verify_local_browser(browser = :firefox, platform = :desktop, headless = false)
+        expect(WebDriverConnect.num_drivers).to eq(1)
       end
 
       it 'connects to a local Safari browser' do


### PR DESCRIPTION
`WebDriverConnect.num_drivers` no longer raises exception if called before any WebDrivers have been instantiated.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have added tests (specs and/or Cucumber tests) that prove my fix is effective or that my feature works
- [x] Specs and/or Cucumber tests pass locally with my changes
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
