### PR TITLE
Fix WebDriverConnect.activate_driver and close_all_drivers failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 All notable changes to this project will be documented in this file.
 
 
+## [4.4.7] - 13-JAN-2024
+
+### Fixed
+* `WebDriverConnect.activate_driver` now correctly sets `Environ.driver_name` to name of activated WebDriver instance.
+* `WebDriverConnect.close_all_drivers` no longer raises exception if called before any WebDrivers have been instantiated.
+
+### Added
+* Added `WebDriverConnect.driver_exists?` method.
+
 ## [4.4.6] - 12-JAN-2024
 
 ### Fixed

--- a/lib/testcentricity_web/version.rb
+++ b/lib/testcentricity_web/version.rb
@@ -1,3 +1,3 @@
 module TestCentricityWeb
-  VERSION = '4.4.6'
+  VERSION = '4.4.7'
 end

--- a/lib/testcentricity_web/web_core/webdriver_helper.rb
+++ b/lib/testcentricity_web/web_core/webdriver_helper.rb
@@ -109,13 +109,23 @@ module TestCentricity
       @drivers[Environ.driver_name] = Environ.driver_state
     end
 
-    def self.activate_driver(driver_name)
-      driver_state = @drivers[driver_name]
-      raise "Could not find a driver named '#{driver_name}'" if driver_state.nil?
+    def self.driver_exists?(driver_name)
+      if @drivers.nil?
+        false
+      else
+        driver_state = @drivers[driver_name]
+        !driver_state.nil?
+      end
+    end
+
+    def self.activate_driver(name)
+      driver_state = @drivers[name]
+      raise "Could not find a driver named '#{name}'" if driver_state.nil?
 
       Environ.restore_driver_state(driver_state)
-      Capybara.current_driver = driver_name
-      Capybara.default_driver = driver_name
+      Capybara.current_driver = name
+      Capybara.default_driver = name
+      Environ.driver_name = name
     end
 
     # Return the number of driver instances
@@ -127,6 +137,7 @@ module TestCentricity
 
     # Close all browsers and terminate all driver instances
     def self.close_all_drivers
+      return if @drivers.nil?
       @drivers.each do |key, _value|
         Environ.restore_driver_state(@drivers[key])
         Capybara.current_driver = key

--- a/spec/testcentricity_web/webdriver_connect/local_webdriver_spec.rb
+++ b/spec/testcentricity_web/webdriver_connect/local_webdriver_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe TestCentricity::WebDriverConnect, required: true do
         expect(WebDriverConnect.num_drivers).to eq(0)
       end
 
+      it 'driver_exists? returns false when no named driver exists' do
+        expect(WebDriverConnect.driver_exists?('non_existent_driver')).to eq(false)
+      end
+
       it 'raises exception when no capabilities defined' do
         caps = {
           capabilities: { browserName: :firefox },
@@ -227,6 +231,8 @@ RSpec.describe TestCentricity::WebDriverConnect, required: true do
     expect(Environ.is_web?).to eq(true)
     expect(Environ.grid).to eq(nil)
     driver_name = "local_#{Environ.browser}".downcase.to_sym if driver_name.nil?
+    expect(Environ.driver_name).to eq(driver_name)
     expect(Capybara.current_driver).to eq(driver_name)
+    expect(WebDriverConnect.driver_exists?(driver_name)).to eq(true)
   end
 end

--- a/spec/testcentricity_web/webdriver_connect/multi_driver_spec.rb
+++ b/spec/testcentricity_web/webdriver_connect/multi_driver_spec.rb
@@ -257,6 +257,7 @@ RSpec.describe TestCentricity::WebDriverConnect, multi_driver_spec: true do
     expect(Environ.is_web?).to eq(true)
     expect(Environ.grid).to eq(nil)
     driver_name = "local_#{Environ.browser}".downcase.to_sym if driver_name.nil?
+    expect(Environ.driver_name).to eq(driver_name)
     expect(Capybara.current_driver).to eq(driver_name)
   end
 
@@ -280,6 +281,7 @@ RSpec.describe TestCentricity::WebDriverConnect, multi_driver_spec: true do
       expect(Environ.is_android?).to eq(true)
     end
     driver_name = "appium_#{Environ.browser}".downcase.to_sym if driver_name.nil?
+    expect(Environ.driver_name).to eq(driver_name)
     expect(Capybara.current_driver).to eq(driver_name)
   end
 


### PR DESCRIPTION
* `WebDriverConnect.activate_driver` now correctly sets `Environ.driver_name` to name of activated WebDriver instance.
* `WebDriverConnect.close_all_drivers` no longer raises exception if called before any WebDrivers have been instantiated.
* Added `WebDriverConnect.driver_exists?` method.
* Updated specs

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have added tests (specs and/or Cucumber tests) that prove my fix is effective or that my feature works
- [x] Specs and/or Cucumber tests pass locally with my changes
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules