### PR TITLE
Fix WebDriverConnect.driver_exists? and activate_driver issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes to this project will be documented in this file.
 
 
+## [4.5.1] - 18-JAN-2024
+
+### Fixed
+* `WebDriverConnect.driver_exists?` and `activate_driver` methods now convert string passed as a driver name to a symbol
+with lower case letters and spaces replaced with underscores, which is how `WebDriverConnect.initialize_web_driver` saves
+the driver name.
+
+
 ## [4.5.0] - 16-JAN-2024
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -1493,6 +1493,7 @@ method. Valid `driver:` type values are listed in the table below:
 | `:saucelabs`    | remote browser hosted on Sauce Labs                                                        |
 | `:testingbot`   | remote browser hosted on TestingBot                                                        |
 | `:lambdatest`   | remote browser hosted on LambdaTest                                                        |
+| `:custom`       | remote browser hosted on unsupported cloud based browser hosting services                  |
 
 #### Specifying a Driver Name
 

--- a/lib/testcentricity_web/version.rb
+++ b/lib/testcentricity_web/version.rb
@@ -1,3 +1,3 @@
 module TestCentricityWeb
-  VERSION = '4.5.0'
+  VERSION = '4.5.1'
 end

--- a/lib/testcentricity_web/web_core/webdriver_helper.rb
+++ b/lib/testcentricity_web/web_core/webdriver_helper.rb
@@ -113,12 +113,16 @@ module TestCentricity
       if @drivers.nil?
         false
       else
+        driver_name = driver_name.gsub(/\s+/, '_').downcase.to_sym if driver_name.is_a?(String)
         driver_state = @drivers[driver_name]
         !driver_state.nil?
       end
     end
 
     def self.activate_driver(name)
+      name = name.gsub(/\s+/, '_').downcase.to_sym if name.is_a?(String)
+      return if Environ.driver_name == name
+
       driver_state = @drivers[name]
       raise "Could not find a driver named '#{name}'" if driver_state.nil?
 

--- a/spec/testcentricity_web/webdriver_connect/local_webdriver_spec.rb
+++ b/spec/testcentricity_web/webdriver_connect/local_webdriver_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe TestCentricity::WebDriverConnect, required: true do
         WebDriverConnect.initialize_web_driver(caps)
         verify_local_browser(browser = :firefox, platform = :desktop, headless = false)
         expect(WebDriverConnect.num_drivers).to eq(1)
+        expect(WebDriverConnect.driver_exists?('local firefox')).to eq(true)
       end
 
       it 'connects to a local Safari browser' do


### PR DESCRIPTION
**Bug:**
`WebDriverConnect.driver_exists?` and `activate_driver` methods fail to find existing driver if the passed driver name is a string with embedded spaces or has mixed case - i.e. 'Moose and Squirrel'

## Proposed changes

Convert string passed as a driver name to a symbol with lower case letters and spaces replaced with underscores, which is how `WebDriverConnect.initialize_web_driver` saved the driver name.
* `WebDriverConnect.driver_exists?` and `activate_driver` methods now convert passed string to a symbol that will match `driver_name` saved by `WebDriverConnect.initialize_web_driver`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have added tests (specs and/or Cucumber tests) that prove my fix is effective or that my feature works
- [x] Specs and/or Cucumber tests pass locally with my changes
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules