### PR TITLE
Update gems and refactor /downloads folder creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 All notable changes to this project will be documented in this file.
 
 
+## [4.5.8] - 21-MAY-2024
+
+### Changed
+
+* Setting `DOWNLOADS` Environment Variable to `true` will create a `/downloads` folder which will be used as the destination
+for files that are downloaded by your automated tests. You know longer need to manually create the `/downloads` folder.
+* Updated `appium_lib` gem to version 15.1.0.
+* Updated `appium_lib_core` gem to version 9.1.1.
+* Updated `selenium-webdriver` gem to version 4.21.1.
+
+
 ## [4.5.7] - 25-APR-2024
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1625,9 +1625,9 @@ Below is an example of an `options` hash for specifying a connection to a locall
 #### Testing File Downloads With Desktop Browsers
 
 File download functionality can be tested with locally hosted instances of Chrome, Edge, or Firefox desktop browsers. Your
-automation project must include a `/downloads` folder which is used as the destination for files that are downloaded by
-your automated tests. The `/downloads` folder must be at the same level as the `/config` and `/features` folders, as depicted
-below:
+automation project must set the `DOWNLOADS` Environment Variable to `true`, which will result in a `/downloads` folder being
+created, which will be used as the destination for files that are downloaded by your automated tests. The `/downloads` folder
+will be at the same level as the `/config` and `/features` folders, as depicted below:
 
         📁 my_automation_project/
         ├── 📁 config/

--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -25,10 +25,10 @@ parallel: PARALLEL=true REPORTING=true --require features --format pretty --form
 #==============
 
 local:   TEST_ENVIRONMENT=LOCAL
-chrome:  WEB_BROWSER=chrome DATA_SOURCE=yaml <%= desktop %>
+chrome:  WEB_BROWSER=chrome DATA_SOURCE=yaml DOWNLOADS=true <%= desktop %>
 edge:    WEB_BROWSER=edge DATA_SOURCE=json <%= desktop %>
 safari:  WEB_BROWSER=safari DATA_SOURCE=json <%= desktop %>
-firefox: WEB_BROWSER=firefox <%= desktop %>
+firefox: WEB_BROWSER=firefox DOWNLOADS=true <%= desktop %>
 
 chrome_local:  --profile local --profile chrome
 edge_local:    --profile local --profile edge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3"
 services:
   chrome:
-    image: selenium/node-chrome:4.20.0-20240425
+    image: selenium/node-chrome:4.21.0-20240517
     shm_size: 2gb
     depends_on:
       - selenium-hub
@@ -18,7 +18,7 @@ services:
       - ./downloads:/home/seluser/Downloads
 
   edge:
-    image: selenium/node-edge:4.20.0-20240425
+    image: selenium/node-edge:4.21.0-20240517
     shm_size: 2gb
     depends_on:
       - selenium-hub
@@ -32,7 +32,7 @@ services:
       - ./downloads:/home/seluser/Downloads
 
   firefox:
-    image: selenium/node-firefox:4.20.0-20240425
+    image: selenium/node-firefox:4.21.0-20240517
     shm_size: 2gb
     depends_on:
       - selenium-hub
@@ -46,7 +46,7 @@ services:
       - ./downloads:/home/seluser/Downloads
 
   selenium-hub:
-    image: selenium/hub:4.20.0-20240425
+    image: selenium/hub:4.21.0-20240517
     container_name: selenium-hub
     ports:
       - "4442:4442"

--- a/downloads/.keep
+++ b/downloads/.keep
@@ -1,1 +1,0 @@
-Placeholder file to allow the downloads folder to be saved to a repository. This folder is required for receiving files that are downloaded during test execution.

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -22,6 +22,8 @@ end
 AfterAll do
   # close driver
   terminate_session
+  # remove Downloads folder if one was created
+  Dir.delete(WebDriverConnect.downloads_path) if Dir.exist?(WebDriverConnect.downloads_path)
   # terminate Appium Server if command line option was specified and target browser is mobile simulator or device
   if ENV['APPIUM_SERVER'] == 'run' && Environ.driver == :appium && $server.running?
     $server.stop

--- a/lib/testcentricity_web/version.rb
+++ b/lib/testcentricity_web/version.rb
@@ -1,3 +1,3 @@
 module TestCentricityWeb
-  VERSION = '4.5.7'
+  VERSION = '4.5.8'
 end

--- a/lib/testcentricity_web/web_core/webdriver_helper.rb
+++ b/lib/testcentricity_web/web_core/webdriver_helper.rb
@@ -157,6 +157,10 @@ module TestCentricity
       @initialized = false
     end
 
+    def self.downloads_path
+      @downloads_path
+    end
+
     def self.initialize_browser_size
       # tile browser windows if BROWSER_TILE environment variable is true and running in multiple parallel threads
       if ENV['BROWSER_TILE'] && (Environ.parallel || @drivers.length > 1)
@@ -216,8 +220,12 @@ module TestCentricity
 
     def self.initialize_downloads
       @drivers = {}
-      # set downloads folder path
       @downloads_path = "#{Dir.pwd}/downloads"
+      # create downloads folder if it doesn't already exist
+      if ENV['DOWNLOADS'] && ENV['DOWNLOADS'].to_bool
+        Dir.mkdir(@downloads_path) unless Dir.exist?(@downloads_path)
+      end
+
       if ENV['PARALLEL']
         Environ.parallel = true
         Environ.process_num = ENV['TEST_ENV_NUMBER']
@@ -746,7 +754,7 @@ module TestCentricity
       options.add_argument("--lang=#{ENV['LOCALE']}") if ENV['LOCALE']
       if browser == :chrome_headless || browser == :edge_headless
         Environ.headless = true
-        options.add_argument('--headless')
+        options.add_argument('--headless=new')
         options.add_argument('--disable-gpu')
       end
       options

--- a/spec/testcentricity_web/webdriver_connect/grid_webdriver_spec.rb
+++ b/spec/testcentricity_web/webdriver_connect/grid_webdriver_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe TestCentricity::WebDriverConnect, grid: true do
 
   before(:context) do
     ENV['DRIVER'] = 'grid'
+    ENV['DOWNLOADS'] = 'true'
     endpoint = 'http://localhost:4444/wd/hub'
     ENV['REMOTE_ENDPOINT'] = endpoint
     # wait for Dockerized Selenium grid to be running
@@ -254,6 +255,8 @@ RSpec.describe TestCentricity::WebDriverConnect, grid: true do
     WebDriverConnect.close_all_drivers
     # verify that all driver instances have been closed
     expect(WebDriverConnect.num_drivers).to eq(0)
+    # remove Downloads folder if one was created
+    Dir.delete(WebDriverConnect.downloads_path) if Dir.exist?(WebDriverConnect.downloads_path)
   end
 
   def verify_grid_browser(browser, platform, headless, driver_name = nil)
@@ -270,5 +273,6 @@ RSpec.describe TestCentricity::WebDriverConnect, grid: true do
     expect(Environ.grid).to eq(:selenium_grid)
     driver_name = "remote_#{Environ.browser}".downcase.to_sym if driver_name.nil?
     expect(Capybara.current_driver).to eq(driver_name)
+    expect(Dir.exist?(WebDriverConnect.downloads_path)).to eq(true)
   end
 end

--- a/spec/testcentricity_web/webdriver_connect/local_webdriver_spec.rb
+++ b/spec/testcentricity_web/webdriver_connect/local_webdriver_spec.rb
@@ -3,6 +3,10 @@
 RSpec.describe TestCentricity::WebDriverConnect, required: true do
   include_context 'test_site'
 
+  before(:each) do
+    ENV['DOWNLOADS'] = 'false'
+  end
+
   context 'Connect to locally hosted desktop web browsers using W3C desired_capabilities hash' do
     context 'local web browser instances' do
       it 'num_drivers returns 0 when no WebDrivers have been instantiated' do
@@ -21,7 +25,7 @@ RSpec.describe TestCentricity::WebDriverConnect, required: true do
         expect { WebDriverConnect.initialize_web_driver(caps) }.to raise_error('invalid_driver is not a supported driver')
       end
 
-      it 'raises exception when no :browserName is specified' do
+      it 'raises exception when no browserName is specified' do
         caps = {
           capabilities: { orientation: :portrait },
           driver: :webdriver
@@ -36,9 +40,9 @@ RSpec.describe TestCentricity::WebDriverConnect, required: true do
         }
         WebDriverConnect.initialize_web_driver(caps)
         verify_local_browser(
-          browser = :firefox,
-          platform = :desktop,
-          headless = false
+          browser_type = :firefox,
+          platform_type = :desktop,
+          is_is_headless = false
         )
         expect(WebDriverConnect.num_drivers).to eq(1)
         expect(WebDriverConnect.driver_exists?('local firefox')).to eq(true)
@@ -51,9 +55,9 @@ RSpec.describe TestCentricity::WebDriverConnect, required: true do
         }
         WebDriverConnect.initialize_web_driver(caps)
         verify_local_browser(
-          browser = :safari,
-          platform = :desktop,
-          headless = false
+          browser_type = :safari,
+          platform_type = :desktop,
+          is_is_headless = false
         )
       end
 
@@ -65,9 +69,9 @@ RSpec.describe TestCentricity::WebDriverConnect, required: true do
         }
         WebDriverConnect.initialize_web_driver(caps)
         verify_local_browser(
-          browser = :chrome,
-          platform = :desktop,
-          headless = false
+          browser_type = :chrome,
+          platform_type = :desktop,
+          is_headless = false
         )
       end
 
@@ -79,9 +83,9 @@ RSpec.describe TestCentricity::WebDriverConnect, required: true do
         }
         WebDriverConnect.initialize_web_driver(caps)
         verify_local_browser(
-          browser = :edge,
-          platform = :desktop,
-          headless = false
+          browser_type = :edge,
+          platform_type = :desktop,
+          is_headless = false
         )
         expect(Environ.browser_size).to eq([1100, 900])
       end
@@ -93,9 +97,9 @@ RSpec.describe TestCentricity::WebDriverConnect, required: true do
         }
         WebDriverConnect.initialize_web_driver(caps)
         verify_local_browser(
-          browser = :ipad_pro_12_9,
-          platform = :mobile,
-          headless = false
+          browser_type = :ipad_pro_12_9,
+          platform_type = :mobile,
+          is_headless = false
         )
         expect(Environ.device_orientation).to eq(:landscape)
         expect(Environ.browser_size).to eq([1366, 1024])
@@ -108,9 +112,9 @@ RSpec.describe TestCentricity::WebDriverConnect, required: true do
         }
         WebDriverConnect.initialize_web_driver(caps)
         verify_local_browser(
-          browser = :ipad_mini_os16,
-          platform = :mobile,
-          headless = false
+          browser_type = :ipad_mini_os16,
+          platform_type = :mobile,
+          is_headless = false
         )
         expect(Environ.device_orientation).to eq(:landscape)
         expect(Environ.browser_size).to eq([1133, 744])
@@ -126,9 +130,9 @@ RSpec.describe TestCentricity::WebDriverConnect, required: true do
         }
         WebDriverConnect.initialize_web_driver(caps)
         verify_local_browser(
-          browser = :ipad_pro_12_9,
-          platform = :mobile,
-          headless = false
+          browser_type = :ipad_pro_12_9,
+          platform_type = :mobile,
+          is_headless = false
         )
         expect(Environ.device_orientation).to eq(:portrait)
         expect(Environ.browser_size).to eq([1024, 1366])
@@ -143,9 +147,9 @@ RSpec.describe TestCentricity::WebDriverConnect, required: true do
         }
         WebDriverConnect.initialize_web_driver(caps)
         verify_local_browser(
-          browser = :firefox,
-          platform = :desktop,
-          headless = false,
+          browser_type = :firefox,
+          platform_type = :desktop,
+          is_headless = false,
           driver_name = :my_custom_firefox_driver
         )
       end
@@ -159,9 +163,9 @@ RSpec.describe TestCentricity::WebDriverConnect, required: true do
         }
         WebDriverConnect.initialize_web_driver(caps)
         verify_local_browser(
-          browser = :chrome_headless,
-          platform = :desktop,
-          headless = true
+          browser_type = :chrome_headless,
+          platform_type = :desktop,
+          is_headless = true
         )
       end
 
@@ -172,9 +176,9 @@ RSpec.describe TestCentricity::WebDriverConnect, required: true do
         }
         WebDriverConnect.initialize_web_driver(caps)
         verify_local_browser(
-          browser = :edge_headless,
-          platform = :desktop,
-          headless = true
+          browser_type = :edge_headless,
+          platform_type = :desktop,
+          is_headless = true
         )
       end
 
@@ -185,9 +189,9 @@ RSpec.describe TestCentricity::WebDriverConnect, required: true do
         }
         WebDriverConnect.initialize_web_driver(caps)
         verify_local_browser(
-          browser = :firefox_headless,
-          platform = :desktop,
-          headless = true
+          browser_type = :firefox_headless,
+          platform_type = :desktop,
+          is_headless = true
         )
       end
     end
@@ -196,12 +200,13 @@ RSpec.describe TestCentricity::WebDriverConnect, required: true do
   context 'Connect to locally hosted desktop web browsers using environment variables' do
     context 'local web browser instances' do
       it 'connects to a local Firefox browser' do
+        ENV['DOWNLOADS'] = 'true'
         ENV['WEB_BROWSER'] = 'firefox'
         WebDriverConnect.initialize_web_driver
         verify_local_browser(
-          browser = :firefox,
-          platform = :desktop,
-          headless = false
+          browser_type = :firefox,
+          platform_type = :desktop,
+          is_headless = false
         )
       end
 
@@ -209,21 +214,22 @@ RSpec.describe TestCentricity::WebDriverConnect, required: true do
         ENV['WEB_BROWSER'] = 'safari'
         WebDriverConnect.initialize_web_driver
         verify_local_browser(
-          browser = :safari,
-          platform = :desktop,
-          headless = false
+          browser_type = :safari,
+          platform_type = :desktop,
+          is_headless = false
         )
       end
 
       it 'connects to a local Chrome browser' do
+        ENV['DOWNLOADS'] = 'true'
         ENV['WEB_BROWSER'] = 'chrome'
         ENV['BROWSER_SIZE'] = 'max'
         WebDriverConnect.initialize_web_driver
         Browsers.suppress_js_leave_page_modal
         verify_local_browser(
-          browser = :chrome,
-          platform = :desktop,
-          headless = false
+          browser_type = :chrome,
+          platform_type = :desktop,
+          is_headless = false
         )
       end
 
@@ -233,9 +239,9 @@ RSpec.describe TestCentricity::WebDriverConnect, required: true do
         WebDriverConnect.initialize_web_driver
         Browsers.suppress_js_alerts
         verify_local_browser(
-          browser = :edge,
-          platform = :desktop,
-          headless = false
+          browser_type = :edge,
+          platform_type = :desktop,
+          is_headless = false
         )
         expect(Environ.browser_size).to eq([1300, 1000])
       end
@@ -246,9 +252,9 @@ RSpec.describe TestCentricity::WebDriverConnect, required: true do
         WebDriverConnect.initialize_web_driver
         Browsers.set_device_orientation(:landscape)
         verify_local_browser(
-          browser = :ipad_pro_12_9,
-          platform = :mobile,
-          headless = false
+          browser_type = :ipad_pro_12_9,
+          platform_type = :mobile,
+          is_headless = false
         )
         expect(Environ.device_orientation).to eq(:landscape)
         expect(Environ.browser_size).to eq([1366, 1024])
@@ -261,9 +267,9 @@ RSpec.describe TestCentricity::WebDriverConnect, required: true do
         WebDriverConnect.initialize_web_driver
         Browsers.maximize_browser
         verify_local_browser(
-          browser = :chrome_headless,
-          platform = :desktop,
-          headless = true
+          browser_type = :chrome_headless,
+          platform_type = :desktop,
+          is_headless = true
         )
       end
 
@@ -272,9 +278,9 @@ RSpec.describe TestCentricity::WebDriverConnect, required: true do
         WebDriverConnect.initialize_web_driver
         Browsers.refresh_browser
         verify_local_browser(
-          browser = :edge_headless,
-          platform = :desktop,
-          headless = true
+          browser_type = :edge_headless,
+          platform_type = :desktop,
+          is_headless = true
         )
       end
 
@@ -283,9 +289,9 @@ RSpec.describe TestCentricity::WebDriverConnect, required: true do
         WebDriverConnect.initialize_web_driver
         Browsers.delete_all_cookies
         verify_local_browser(
-          browser = :firefox_headless,
-          platform = :desktop,
-          headless = true
+          browser_type = :firefox_headless,
+          platform_type = :desktop,
+          is_headless = true
         )
       end
     end
@@ -293,16 +299,20 @@ RSpec.describe TestCentricity::WebDriverConnect, required: true do
 
   after(:each) do
     WebDriverConnect.close_all_drivers
+    # remove Downloads folder if one was created
+    unless WebDriverConnect.downloads_path.nil?
+      Dir.delete(WebDriverConnect.downloads_path) if Dir.exist?(WebDriverConnect.downloads_path)
+    end
   end
 
-  def verify_local_browser(browser, platform, headless, driver_name = nil)
+  def verify_local_browser(browser_type, platform_type, is_headless, driver_name = nil)
     # load Apple web site
     Capybara.page.driver.browser.navigate.to(test_site_url)
     Capybara.page.find(:css, test_site_locator, wait: 10, visible: true)
     # verify Environs are correctly set
-    expect(Environ.browser).to eq(browser)
-    expect(Environ.platform).to eq(platform)
-    expect(Environ.headless).to eq(headless)
+    expect(Environ.browser).to eq(browser_type)
+    expect(Environ.platform).to eq(platform_type)
+    expect(Environ.headless).to eq(is_headless)
     expect(Environ.session_state).to eq(:running)
     expect(Environ.driver).to eq(:webdriver)
     expect(Environ.device).to eq(:web)
@@ -312,6 +322,7 @@ RSpec.describe TestCentricity::WebDriverConnect, required: true do
     expect(Environ.driver_name).to eq(driver_name)
     expect(Capybara.current_driver).to eq(driver_name)
     expect(WebDriverConnect.driver_exists?(driver_name)).to eq(true)
+    expect(Dir.exist?(WebDriverConnect.downloads_path)).to eq(ENV['DOWNLOADS'].to_bool)
   end
 end
 

--- a/spec/testcentricity_web/webdriver_connect/mobile_webdriver_spec.rb
+++ b/spec/testcentricity_web/webdriver_connect/mobile_webdriver_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe TestCentricity::WebDriverConnect, mobile: true do
         }
       }
       WebDriverConnect.initialize_web_driver(caps)
-      verify_mobile_browser(browser = :safari, device_os = :ios)
+      verify_mobile_browser(browser_type = :safari, os = :ios)
       expect(Environ.device_name).to eq('iPad Pro (12.9-inch) (6th generation)')
       expect(Environ.device_os_version).to eq('17.2')
       expect(Environ.device_orientation).to eq(:landscape)
@@ -49,7 +49,7 @@ RSpec.describe TestCentricity::WebDriverConnect, mobile: true do
         }
       }
       WebDriverConnect.initialize_web_driver(caps)
-      verify_mobile_browser(browser = :chrome, device_os = :android)
+      verify_mobile_browser(browser_type = :chrome, os = :android)
       expect(Environ.device_name).to eq('Pixel_C_API_31')
       expect(Environ.device_os_version).to eq('12.0')
       expect(Environ.device_orientation).to eq(:portrait)
@@ -71,7 +71,7 @@ RSpec.describe TestCentricity::WebDriverConnect, mobile: true do
         endpoint: 'http://localhost:4723'
       }
       WebDriverConnect.initialize_web_driver(caps)
-      verify_mobile_browser(browser = :safari, device_os = :ios, driver_name = :my_custom_ios_driver)
+      verify_mobile_browser(browser_type = :safari, os = :ios, driver_name = :my_custom_ios_driver)
       expect(Environ.device_name).to eq('iPad Pro (12.9-inch) (6th generation)')
       expect(Environ.device_os_version).to eq('17.2')
       expect(Environ.device_orientation).to eq(:landscape)
@@ -94,7 +94,7 @@ RSpec.describe TestCentricity::WebDriverConnect, mobile: true do
         }
       }
       WebDriverConnect.initialize_web_driver(caps)
-      verify_mobile_browser(browser = :chrome, device_os = :android, driver_name = :my_custom_android_driver)
+      verify_mobile_browser(browser_type = :chrome, os = :android, driver_name = :my_custom_android_driver)
       expect(Environ.device_name).to eq('Pixel_C_API_31')
       expect(Environ.device_os_version).to eq('12.0')
       expect(Environ.device_orientation).to eq(:portrait)
@@ -111,7 +111,7 @@ RSpec.describe TestCentricity::WebDriverConnect, mobile: true do
       ENV['APP_DEVICE'] = 'iPad Pro (12.9-inch) (6th generation)'
       ENV['ORIENTATION'] = 'portrait'
       WebDriverConnect.initialize_web_driver
-      verify_mobile_browser(browser = :safari, device_os = :ios)
+      verify_mobile_browser(browser_type = :safari, os = :ios)
       expect(Environ.device_name).to eq(ENV['APP_DEVICE'])
       expect(Environ.device_os_version).to eq(ENV['APP_VERSION'])
       expect(Environ.device_orientation).to eq(:portrait)
@@ -126,20 +126,20 @@ RSpec.describe TestCentricity::WebDriverConnect, mobile: true do
       ENV['APP_DEVICE'] = 'Pixel_C_API_31'
       ENV['ORIENTATION'] = 'landscape'
       WebDriverConnect.initialize_web_driver
-      verify_mobile_browser(browser = :chrome, device_os = :android)
+      verify_mobile_browser(browser_type = :chrome, os = :android)
       expect(Environ.device_name).to eq(ENV['APP_DEVICE'])
       expect(Environ.device_os_version).to eq(ENV['APP_VERSION'])
       expect(Environ.device_orientation).to eq(:landscape)
     end
   end
 
-  def verify_mobile_browser(browser, device_os, driver_name = nil)
+  def verify_mobile_browser(browser_type, os, driver_name = nil)
     # load Apple web site
     Capybara.page.driver.browser.navigate.to(test_site_url)
     Capybara.page.find(:css, test_site_locator, wait: 10, visible: true)
     # verify Environs are correctly set
-    expect(Environ.browser).to eq(browser)
-    expect(Environ.device_os).to eq(device_os)
+    expect(Environ.browser).to eq(browser_type)
+    expect(Environ.device_os).to eq(os)
     expect(Environ.platform).to eq(:mobile)
     expect(Environ.headless).to eq(false)
     expect(Environ.session_state).to eq(:running)
@@ -147,7 +147,7 @@ RSpec.describe TestCentricity::WebDriverConnect, mobile: true do
     expect(Environ.device).to eq(:simulator)
     expect(Environ.device_type).to eq(:tablet)
     expect(Environ.is_web?).to eq(false)
-    if device_os == :ios
+    if os == :ios
       expect(Environ.is_ios?).to eq(true)
     else
       expect(Environ.is_android?).to eq(true)

--- a/spec/testcentricity_web/webdriver_connect/saucelabs_spec.rb
+++ b/spec/testcentricity_web/webdriver_connect/saucelabs_spec.rb
@@ -21,25 +21,25 @@ RSpec.describe TestCentricity::WebDriverConnect, saucelabs: true do
     it 'connects to a Safari browser on SauceLabs' do
       ENV['SL_BROWSER'] = 'Safari'
       WebDriverConnect.initialize_web_driver
-      verify_cloud_browser(browser = :safari, platform = :desktop)
+      verify_cloud_browser(browser_type = :safari, platform = :desktop)
     end
 
     it 'connects to a Chrome browser on SauceLabs' do
       ENV['SL_BROWSER'] = 'Chrome'
       WebDriverConnect.initialize_web_driver
-      verify_cloud_browser(browser = :chrome, platform = :desktop)
+      verify_cloud_browser(browser_type = :chrome, platform = :desktop)
     end
 
     it 'connects to a Firefox browser on SauceLabs' do
       ENV['SL_BROWSER'] = 'Firefox'
       WebDriverConnect.initialize_web_driver
-      verify_cloud_browser(browser = :firefox, platform = :desktop)
+      verify_cloud_browser(browser_type = :firefox, platform = :desktop)
     end
 
     it 'connects to an Edge browser on SauceLabs' do
       ENV['SL_BROWSER'] = 'MicrosoftEdge'
       WebDriverConnect.initialize_web_driver
-      verify_cloud_browser(browser = :microsoftedge, platform = :desktop)
+      verify_cloud_browser(browser_type = :microsoftedge, platform = :desktop)
     end
   end
 
@@ -67,25 +67,25 @@ RSpec.describe TestCentricity::WebDriverConnect, saucelabs: true do
     it 'connects to a Safari browser on SauceLabs' do
       ENV['SL_BROWSER'] = 'Safari'
       WebDriverConnect.initialize_web_driver(desktop_caps_hash)
-      verify_cloud_browser(browser = :safari, platform = :desktop)
+      verify_cloud_browser(browser_type = :safari, platform = :desktop)
     end
 
     it 'connects to a Chrome browser on SauceLabs' do
       ENV['SL_BROWSER'] = 'Chrome'
       WebDriverConnect.initialize_web_driver(desktop_caps_hash)
-      verify_cloud_browser(browser = :chrome, platform = :desktop)
+      verify_cloud_browser(browser_type = :chrome, platform = :desktop)
     end
 
     it 'connects to a Firefox browser on SauceLabs' do
       ENV['SL_BROWSER'] = 'Firefox'
       WebDriverConnect.initialize_web_driver(desktop_caps_hash)
-      verify_cloud_browser(browser = :firefox, platform = :desktop)
+      verify_cloud_browser(browser_type = :firefox, platform = :desktop)
     end
 
     it 'connects to an Edge browser on SauceLabs' do
       ENV['SL_BROWSER'] = 'MicrosoftEdge'
       WebDriverConnect.initialize_web_driver(desktop_caps_hash)
-      verify_cloud_browser(browser = :microsoftedge, platform = :desktop)
+      verify_cloud_browser(browser_type = :microsoftedge, platform = :desktop)
     end
   end
 
@@ -99,7 +99,7 @@ RSpec.describe TestCentricity::WebDriverConnect, saucelabs: true do
       ENV['AUTOMATION_ENGINE'] = 'XCUITest'
       ENV['ORIENTATION'] = 'landscape'
       WebDriverConnect.initialize_web_driver
-      verify_cloud_browser(browser = :safari, platform = :mobile, device = ENV['SL_DEVICE'])
+      verify_cloud_browser(browser_type = :safari, platform = :mobile, device = ENV['SL_DEVICE'])
     end
 
     it 'connects to a mobile Chrome browser on an Android tablet on SauceLabs' do
@@ -111,7 +111,7 @@ RSpec.describe TestCentricity::WebDriverConnect, saucelabs: true do
       ENV['AUTOMATION_ENGINE'] = 'UiAutomator2'
       ENV['ORIENTATION'] = 'landscape'
       WebDriverConnect.initialize_web_driver
-      verify_cloud_browser(browser = :chrome, platform = :mobile, device = ENV['SL_DEVICE'])
+      verify_cloud_browser(browser_type = :chrome, platform = :mobile, device = ENV['SL_DEVICE'])
     end
   end
 
@@ -137,7 +137,7 @@ RSpec.describe TestCentricity::WebDriverConnect, saucelabs: true do
         }
       }
       WebDriverConnect.initialize_web_driver(caps)
-      verify_cloud_browser(browser = :safari,
+      verify_cloud_browser(browser_type = :safari,
                            platform = :mobile,
                            device = 'iPad Pro (12.9 inch) (5th generation) Simulator')
     end
@@ -163,7 +163,7 @@ RSpec.describe TestCentricity::WebDriverConnect, saucelabs: true do
         }
       }
       WebDriverConnect.initialize_web_driver(caps)
-      verify_cloud_browser(browser = :chrome,
+      verify_cloud_browser(browser_type = :chrome,
                            platform = :mobile,
                            device = 'Samsung Galaxy Tab S7 Plus GoogleAPI Emulator')
     end
@@ -175,12 +175,12 @@ RSpec.describe TestCentricity::WebDriverConnect, saucelabs: true do
     expect(WebDriverConnect.num_drivers).to eq(0)
   end
 
-  def verify_cloud_browser(browser, platform, device = nil)
+  def verify_cloud_browser(browser_type, platform, device = nil)
     # load Apple web site
     Capybara.page.driver.browser.navigate.to(test_site_url)
     Capybara.page.find(:css, test_site_locator, wait: 10, visible: true)
     # verify Environs are correctly set
-    expect(Environ.browser).to eq(browser)
+    expect(Environ.browser).to eq(browser_type)
     expect(Environ.platform).to eq(platform)
     expect(Environ.session_state).to eq(:running)
     expect(Environ.driver).to eq(:saucelabs)

--- a/testcentricity_web.gemspec
+++ b/testcentricity_web.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
     appropriate Selenium-Webdriver capabilities required to establish connections to locally hosted desktop browsers,
     locally hosted emulated mobile browsers (iOS, Android, etc.) running within a local instance of Chrome, mobile Safari
     browsers on iOS device simulators or physical iOS devices, mobile Chrome browsers on Android Studio virtual device
-    emulators, or cloud hosted desktop or mobile web browsers (using BrowserStack, Sauce Labs, TestingBot, or
-    LambdaTest services).'
+    emulators, or cloud hosted desktop or mobile web browsers (using BrowserStack, Sauce Labs, TestingBot, or LambdaTest
+    services).'
   spec.homepage      = 'https://github.com/TestCentricity/testcentricity_web'
   spec.license       = 'BSD-3-Clause'
   spec.metadata = {
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', ['~> 0.18']
   spec.add_development_dependency 'yard', ['>= 0.9.0']
 
-  spec.add_runtime_dependency 'appium_lib', '~> 15.0.0'
+  spec.add_runtime_dependency 'appium_lib', '~> 15.1.0'
   spec.add_runtime_dependency 'browserstack-local'
   spec.add_runtime_dependency 'capybara', '3.40.0'
   spec.add_runtime_dependency 'childprocess'
@@ -52,7 +52,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'faker'
   spec.add_runtime_dependency 'i18n'
   spec.add_runtime_dependency 'os', '~> 1.0'
-  spec.add_runtime_dependency 'selenium-webdriver', '4.20.0'
+  spec.add_runtime_dependency 'selenium-webdriver', '4.21.1'
   spec.add_runtime_dependency 'test-unit'
   spec.add_runtime_dependency 'virtus'
 end


### PR DESCRIPTION
* Setting `DOWNLOADS` Environment Variable to `true` will create a `/download`s folder which will be used as the destination for files that are downloaded by your automated tests. You know longer need to manually create the `/downloads` folder.
* Updated `appium_lib` gem to version 15.1.0.
* Updated `appium_lib_core` gem to version 9.1.1.
* Updated `selenium-webdriver` gem to version 4.21.1.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have added tests (specs and/or Cucumber tests) that prove my fix is effective or that my feature works
- [x] Specs and/or Cucumber tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules