### PR TITLE
Add cuke_modeler gem as a development dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes to this project will be documented in this file.
 
 
+## [4.5.9.1] - 26-JUNE-2024
+
+### Fixed
+
+* Added `cuke_modeler` gem as a development dependency so that Cucumber test results logging would not fail when running
+tests in parallel with Ruby version 3.10 or greater.
+
+
 ## [4.5.9] - 23-JUNE-2024
 
 ### Changed

--- a/lib/testcentricity_web/version.rb
+++ b/lib/testcentricity_web/version.rb
@@ -1,3 +1,3 @@
 module TestCentricityWeb
-  VERSION = '4.5.9'
+  VERSION = '4.5.9.1'
 end

--- a/spec/testcentricity_web/webdriver_connect/local_webdriver_spec.rb
+++ b/spec/testcentricity_web/webdriver_connect/local_webdriver_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe TestCentricity::WebDriverConnect, required: true do
 
   before(:each) do
     ENV['DOWNLOADS'] = 'false'
+    Dir.delete(WebDriverConnect.downloads_path) if Dir.exist?(WebDriverConnect.downloads_path)
   end
 
   context 'Connect to locally hosted desktop web browsers using W3C desired_capabilities hash' do

--- a/testcentricity_web.gemspec
+++ b/testcentricity_web.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'cucumber', '9.2.0'
+  spec.add_development_dependency 'cuke_modeler', '~> 3.0'
   spec.add_development_dependency 'docker-compose'
   spec.add_development_dependency 'httparty'
   spec.add_development_dependency 'parallel_tests'


### PR DESCRIPTION
## Proposed changes

* Added `cuke_modeler` gem as a development dependency so that Cucumber test results logging would not fail when running tests in parallel with Ruby version 3.10 or greater.
* Delete `downloads` folder as precondition to local webdriver specs.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have added tests (specs and/or Cucumber tests) that prove my fix is effective or that my feature works
- [x] Specs and/or Cucumber tests pass locally with my changes
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules