### PR TITLE
Arm64 specs fix

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,38 @@
+# How TestCentricity™ For Web Is Tested
+
+The TestCentricity™ For Web core framework gem is tested prior to every release using a combination of test specs (RSpec)
+and Cucumber feature tests. Test specs and Cucumber features are executed on a combination of Apple MacOS Ventura running
+on Macs with Intel CPUs (x86 architecture) and MacOS Sequoia running on Macs with Apple Silicon CPUs (arm64 architecture).
+
+The `Rakefile` in this repository defines the individual test spec and Cucumber feature tasks, as well as tasks for running
+combinations of specs and cukes for required, mobile, grid, and release categories.
+
+## Test Specs
+
+Test specs are used to verify connectivity to the following target web browsers:
+* locally hosted desktop browsers (Chrome, Edge, Firefox, and Safari)
+* locally hosted "headless" Chrome, Firefox, and Edge browsers
+* remote Chrome, Firefox, and Edge desktop browsers and emulated mobile web browsers hosted on a Dockerized Selenium 4 environments
+* mobile Safari browsers on iOS device simulators (using Appium 2.x and XCode)
+* mobile Chrome browsers on Android Studio virtual device emulators (using Appium 2.x and Android Studio)
+* cloud hosted desktop browsers (Firefox, Chrome, Safari, IE, and Edge) and mobile browsers (iOS Mobile Safari or Android Chrome) using the following service:
+    * Browserstack
+    * Sauce Labs
+    * TestingBot
+    * LambdaTest
+
+## Cucumber Features
+
+Cucumber feature tests are used to verify the gem's Page Object Model implementation using a locally and grid hosted test
+web site with most of the supported standard UI element types and custom UI based on multiple composite UI components. The
+test web site source code is contained in the `test_site/` folder of this repository.
+
+Cucumber feature tests are executed against the following target web browsers:
+* locally hosted desktop browsers (Chrome, Edge, Firefox, and Safari)
+* locally hosted "headless" Chrome, Firefox, and Edge browsers
+* remote Chrome, Firefox, and Edge desktop browsers and emulated mobile web browsers hosted on a Dockerized Selenium 4 environments
+* mobile Safari browsers on iOS device simulators (using Appium 2.x and XCode)
+* mobile Chrome browsers on Android Studio virtual device emulators (using Appium 2.x and Android Studio)
+
+Cucumber feature tests executed against locally hosted Chrome and Edge browsers are run in 6 concurrent test threads using
+the `parallel_tests` gem, while tests run in the Docker Selenium environment are run in 4 concurrent test threads.

--- a/docker-compose-arm.yml
+++ b/docker-compose-arm.yml
@@ -3,7 +3,7 @@
 # To stop the execution, hit Ctrl+C, and then `docker-compose -f docker-compose.yml down`
 services:
   firefox:
-    image: selenium/node-firefox:4.29.0-20250222
+    image: selenium/node-firefox:4.31.0-20250414
     shm_size: 2gb
     depends_on:
       - selenium-hub
@@ -17,7 +17,7 @@ services:
       - ./downloads:/home/seluser/Downloads
 
   selenium-hub:
-    image: selenium/hub:4.29.0-20250222
+    image: selenium/hub:4.31.0-20250414
     container_name: selenium-hub
     ports:
       - "4442:4442"

--- a/docker-compose-arm.yml
+++ b/docker-compose-arm.yml
@@ -1,0 +1,25 @@
+# To execute this docker-compose yml file use `docker-compose -f docker-compose.yml up`
+# Add the `-d` flag at the end for detached execution
+# To stop the execution, hit Ctrl+C, and then `docker-compose -f docker-compose.yml down`
+services:
+  firefox:
+    image: selenium/node-firefox:4.29.0-20250222
+    shm_size: 2gb
+    depends_on:
+      - selenium-hub
+    environment:
+      - SE_EVENT_BUS_HOST=selenium-hub
+      - SE_EVENT_BUS_PUBLISH_PORT=4442
+      - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
+      - SE_NODE_MAX_SESSIONS=4
+      - SE_NODE_OVERRIDE_MAX_SESSIONS=true
+    volumes:
+      - ./downloads:/home/seluser/Downloads
+
+  selenium-hub:
+    image: selenium/hub:4.29.0-20250222
+    container_name: selenium-hub
+    ports:
+      - "4442:4442"
+      - "4443:4443"
+      - "4444:4444"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@
 # To stop the execution, hit Ctrl+C, and then `docker-compose -f docker-compose.yml down`
 services:
   chrome:
-    image: selenium/node-chrome:4.29.0-20250222
+    image: selenium/node-chrome:4.31.0-20250414
     shm_size: 2gb
     depends_on:
       - selenium-hub
@@ -17,7 +17,7 @@ services:
       - ./downloads:/home/seluser/Downloads
 
   edge:
-    image: selenium/node-edge:4.29.0-20250222
+    image: selenium/node-edge:4.31.0-20250414
     shm_size: 2gb
     depends_on:
       - selenium-hub
@@ -31,7 +31,7 @@ services:
       - ./downloads:/home/seluser/Downloads
 
   firefox:
-    image: selenium/node-firefox:4.29.0-20250222
+    image: selenium/node-firefox:4.31.0-20250414
     shm_size: 2gb
     depends_on:
       - selenium-hub
@@ -45,7 +45,7 @@ services:
       - ./downloads:/home/seluser/Downloads
 
   selenium-hub:
-    image: selenium/hub:4.29.0-20250222
+    image: selenium/hub:4.31.0-20250414
     container_name: selenium-hub
     ports:
       - "4442:4442"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require 'capybara/rspec'
 require 'httparty'
+require 'os'
 require 'require_all'
 require 'simplecov'
 require 'testcentricity_web'

--- a/spec/testcentricity_web/webdriver_connect/grid_webdriver_spec.rb
+++ b/spec/testcentricity_web/webdriver_connect/grid_webdriver_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe TestCentricity::WebDriverConnect, grid: true do
       end
 
       it 'connects to a grid hosted Chrome browser' do
+        arm64_skip_check
         caps = {
           capabilities: { browserName: :chrome },
           driver: :grid,
@@ -47,6 +48,7 @@ RSpec.describe TestCentricity::WebDriverConnect, grid: true do
       end
 
       it 'connects to a grid hosted Edge browser' do
+        arm64_skip_check
         caps = {
           capabilities: { browserName: :edge },
           driver: :grid,
@@ -59,6 +61,7 @@ RSpec.describe TestCentricity::WebDriverConnect, grid: true do
       end
 
       it 'connects to a grid hosted emulated mobile web browser' do
+        arm64_skip_check
         caps = {
           capabilities: { browserName: :ipad_pro_12_9 },
           driver: :grid
@@ -70,6 +73,7 @@ RSpec.describe TestCentricity::WebDriverConnect, grid: true do
       end
 
       it 'connects to a user defined grid hosted emulated mobile web browser with default orientation' do
+        arm64_skip_check
         caps = {
           capabilities: { browserName: :ipad_mini_os16 },
           driver: :grid
@@ -81,6 +85,7 @@ RSpec.describe TestCentricity::WebDriverConnect, grid: true do
       end
 
       it 'connects to a grid hosted Chrome browser with a user-defined driver name' do
+        arm64_skip_check
         caps = {
           browser_size: [1100, 900],
           capabilities: { browserName: :chrome },
@@ -105,6 +110,7 @@ RSpec.describe TestCentricity::WebDriverConnect, grid: true do
 
     context 'grid headless browser instances' do
       it 'connects to a grid hosted headless Chrome browser' do
+        arm64_skip_check
         caps = {
           capabilities: { browserName: :chrome_headless },
           driver: :grid
@@ -114,6 +120,7 @@ RSpec.describe TestCentricity::WebDriverConnect, grid: true do
       end
 
       it 'connects to a grid hosted headless Edge browser' do
+        arm64_skip_check
         caps = {
           capabilities: { browserName: :edge_headless },
           driver: :grid
@@ -134,6 +141,7 @@ RSpec.describe TestCentricity::WebDriverConnect, grid: true do
 
     context 'Connect to multiple grid hosted web browsers' do
       it 'connects to multiple desktop and emulated mobile browsers' do
+        arm64_skip_check
         # instantiate a grid hosted emulated iPad browser
         caps = {
           capabilities: { browserName: :ipad_pro_12_9 },
@@ -201,6 +209,7 @@ RSpec.describe TestCentricity::WebDriverConnect, grid: true do
       end
 
       it 'connects to a grid hosted Chrome browser' do
+        arm64_skip_check
         ENV['WEB_BROWSER'] = 'chrome'
         ENV['BROWSER_SIZE'] = 'max'
         WebDriverConnect.initialize_web_driver
@@ -209,6 +218,7 @@ RSpec.describe TestCentricity::WebDriverConnect, grid: true do
       end
 
       it 'connects to a grid hosted Edge browser' do
+        arm64_skip_check
         ENV['WEB_BROWSER'] = 'edge'
         ENV['BROWSER_SIZE'] = '1300, 1000'
         WebDriverConnect.initialize_web_driver
@@ -218,6 +228,7 @@ RSpec.describe TestCentricity::WebDriverConnect, grid: true do
       end
 
       it 'connects to a grid hosted emulated mobile web browser' do
+        arm64_skip_check
         ENV['WEB_BROWSER'] = 'ipad_pro_12_9'
         ENV['ORIENTATION'] = 'portrait'
         WebDriverConnect.initialize_web_driver
@@ -229,6 +240,7 @@ RSpec.describe TestCentricity::WebDriverConnect, grid: true do
 
     context 'grid headless browser instances' do
       it 'connects to a grid hosted headless Chrome browser' do
+        arm64_skip_check
         ENV['WEB_BROWSER'] = 'chrome_headless'
         WebDriverConnect.initialize_web_driver
         Browsers.maximize_browser
@@ -236,6 +248,7 @@ RSpec.describe TestCentricity::WebDriverConnect, grid: true do
       end
 
       it 'connects to a grid hosted headless Edge browser' do
+        arm64_skip_check
         ENV['WEB_BROWSER'] = 'edge_headless'
         WebDriverConnect.initialize_web_driver
         Browsers.refresh_browser
@@ -257,6 +270,10 @@ RSpec.describe TestCentricity::WebDriverConnect, grid: true do
     expect(WebDriverConnect.num_drivers).to eq(0)
     # remove Downloads folder if one was created
     Dir.delete(WebDriverConnect.downloads_path) if Dir.exist?(WebDriverConnect.downloads_path)
+  end
+
+  def arm64_skip_check
+    skip 'Cannot be executed when running on arm64 architecture' if OS.host_cpu == 'arm64'
   end
 
   def verify_grid_browser(browser, platform, headless, driver_name = nil)


### PR DESCRIPTION
## Proposed changes

`docker_grid_specs` and `grid_cukes` Rake tasks fail when executed on Macs with Apple Silicon (`arm64` architecture) because Chrome and Edge browsers are not supported in Docker-Selenium with `arm64`. Issue #57 

Need to modify `docker_grid_specs` and `grid_cukes` Rake tasks and provide a separate `docker-compose-arm.yml` file for `arm64` platforms. Also need to refactor `grid_webdriver_spec.rb` to check for `arm64` architecture and skip specs targeting Chrome and Edge browsers.

* Skip test specs and cukes for Chrome and Edge browsers when running in Docker Selenium on `arm64` architecture.
* Added `docker-compose-arm.yml` file without Chrome and Edge for `arm64` architecture.
* Update `docker-compose.yml` files to use Selenium version 4.31.0.
* Added `How TestCentricity For Web Is Tested` doc.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have added tests (specs and/or Cucumber tests) that prove my fix is effective or that my feature works
- [x] Specs and/or Cucumber tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules