### PR TITLE
Gem updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 
-## [4.6.6] - 02-OCT-2025
+## [4.6.6] - 10-OCT-2025
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes to this project will be documented in this file.
 
 
+## [4.6.6] - 02-OCT-2025
+
+### Changed
+
+* Update Nokogiri gem to address CVE-2025-6021, CVE-2025-6170, CVE-2025-49794, CVE-2025-49795, and CVE-2025-49796.
+* Update REXML gem to address DoS vulnerability when parsing XML containing multiple XML declarations.
+
+
 ## [4.6.5] - 18-JUL-2025
 
 ### Changed

--- a/docker-compose-arm.yml
+++ b/docker-compose-arm.yml
@@ -3,7 +3,7 @@
 # To stop the execution, hit Ctrl+C, and then `docker-compose -f docker-compose.yml down`
 services:
   firefox:
-    image: selenium/node-firefox:4.32.0-20250515
+    image: selenium/node-firefox:4.35.0-20250909
     shm_size: 2gb
     depends_on:
       - selenium-hub
@@ -17,7 +17,7 @@ services:
       - ./downloads:/home/seluser/Downloads
 
   selenium-hub:
-    image: selenium/hub:4.32.0-20250515
+    image: selenium/hub:4.35.0-20250909
     container_name: selenium-hub
     ports:
       - "4442:4442"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@
 # To stop the execution, hit Ctrl+C, and then `docker-compose -f docker-compose.yml down`
 services:
   chrome:
-    image: selenium/node-chrome:4.32.0-20250515
+    image: selenium/node-chrome:4.35.0-20250909
     shm_size: 2gb
     depends_on:
       - selenium-hub
@@ -17,7 +17,7 @@ services:
       - ./downloads:/home/seluser/Downloads
 
   edge:
-    image: selenium/node-edge:4.32.0-20250515
+    image: selenium/node-edge:4.35.0-20250909
     shm_size: 2gb
     depends_on:
       - selenium-hub
@@ -31,7 +31,7 @@ services:
       - ./downloads:/home/seluser/Downloads
 
   firefox:
-    image: selenium/node-firefox:4.32.0-20250515
+    image: selenium/node-firefox:4.35.0-20250909
     shm_size: 2gb
     depends_on:
       - selenium-hub
@@ -45,7 +45,7 @@ services:
       - ./downloads:/home/seluser/Downloads
 
   selenium-hub:
-    image: selenium/hub:4.32.0-20250515
+    image: selenium/hub:4.35.0-20250909
     container_name: selenium-hub
     ports:
       - "4442:4442"

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -8,8 +8,8 @@ end
 BeforeAll do
   # create Cucumber reports folder if it doesn't already exist
   if ENV['REPORTING']
-    reports_path = "#{Dir.pwd}/reports"
-    Dir.mkdir(reports_path) unless Dir.exist?(reports_path)
+    $reports_path = "#{Dir.pwd}/reports"
+    Dir.mkdir($reports_path) unless Dir.exist?($reports_path)
   end
   # start Appium Server if command line option was specified and target browser is mobile simulator or device
   if ENV['APPIUM_SERVER'] == 'run' && Environ.driver == :appium
@@ -33,7 +33,9 @@ end
 
 Before do |scenario|
   # if executing tests in parallel concurrent threads, print thread number with scenario name
-  message = Environ.parallel ? "Thread ##{Environ.process_num} | Scenario:  #{scenario.name}" : "Scenario:  #{scenario.name}"
+  browser_type = Environ.grid ? "grid hosted #{Environ.browser}" : Environ.browser
+  scenario_name = "Scenario:  #{scenario.name} - #{browser_type}"
+  message = Environ.parallel ? "Thread ##{Environ.process_num} | #{scenario_name}" : scenario_name
   log message
   $initialized ||= false
   unless $initialized
@@ -269,7 +271,7 @@ end
 def screen_shot_and_save_page(scenario)
   timestamp = Time.now.strftime('%Y%m%d%H%M%S%L')
   filename = scenario.nil? ? "Screenshot-#{timestamp}.png" : "Screenshot-#{scenario.__id__}-#{timestamp}.png"
-  path = File.join Dir.pwd, 'reports/screenshots/', filename
+  path = File.join Dir.pwd, "#{$reports_path}/screenshots/", filename
   save_screenshot path
   log "Screenshot saved at #{path}"
   screen_shot = { path: path, filename: filename }

--- a/lib/testcentricity_web/version.rb
+++ b/lib/testcentricity_web/version.rb
@@ -1,3 +1,3 @@
 module TestCentricityWeb
-  VERSION = '4.6.5'
+  VERSION = '4.6.6'
 end

--- a/lib/testcentricity_web/web_core/webdriver_helper.rb
+++ b/lib/testcentricity_web/web_core/webdriver_helper.rb
@@ -486,7 +486,7 @@ module TestCentricity
                   # define mobile device options
                   if ENV['BS_DEVICE']
                     bs_options[:deviceName] = ENV['BS_DEVICE']
-                    bs_options[:appiumVersion] = '2.15.0'
+                    bs_options[:appiumVersion] = '2.19.0'
                     {
                       browserName: browser,
                       'bstack:options': bs_options
@@ -494,7 +494,7 @@ module TestCentricity
                   else
                     # define desktop browser options
                     bs_options[:resolution] = ENV['RESOLUTION'] if ENV['RESOLUTION']
-                    bs_options[:seleniumVersion] = '4.30.0'
+                    bs_options[:seleniumVersion] = '4.35.0'
                     {
                       browserName: browser,
                       browserVersion: ENV['BS_VERSION'],
@@ -564,7 +564,7 @@ module TestCentricity
                   else
                     # define desktop browser options
                     tb_options['screen-resolution'] = ENV['RESOLUTION'] if ENV['RESOLUTION']
-                    tb_options['selenium-version'] = '4.29.0'
+                    tb_options['selenium-version'] = '4.35.0'
                   end
                   {
                     browserName: browser,

--- a/spec/testcentricity_web/webdriver_connect/browserstack_spec.rb
+++ b/spec/testcentricity_web/webdriver_connect/browserstack_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe TestCentricity::WebDriverConnect, browserstack: true do
             os: ENV['BS_OS'],
             osVersion: ENV['BS_OS_VERSION'],
             resolution: ENV['RESOLUTION'],
-            seleniumVersion: '4.30.0'
+            seleniumVersion: '4.35.0'
           }
         }
       }
@@ -61,7 +61,7 @@ RSpec.describe TestCentricity::WebDriverConnect, browserstack: true do
             os: ENV['BS_OS'],
             osVersion: ENV['BS_OS_VERSION'],
             resolution: ENV['RESOLUTION'],
-            seleniumVersion: '4.30.0'
+            seleniumVersion: '4.35.0'
           }
         }
       }
@@ -83,7 +83,7 @@ RSpec.describe TestCentricity::WebDriverConnect, browserstack: true do
             os: ENV['BS_OS'],
             osVersion: ENV['BS_OS_VERSION'],
             resolution: ENV['RESOLUTION'],
-            seleniumVersion: '4.30.0'
+            seleniumVersion: '4.35.0'
           }
         }
       }
@@ -104,7 +104,7 @@ RSpec.describe TestCentricity::WebDriverConnect, browserstack: true do
             os: ENV['BS_OS'],
             osVersion: ENV['BS_OS_VERSION'],
             resolution: ENV['RESOLUTION'],
-            seleniumVersion: '4.30.0'
+            seleniumVersion: '4.35.0'
           }
         }
       }
@@ -147,7 +147,7 @@ RSpec.describe TestCentricity::WebDriverConnect, browserstack: true do
             osVersion: '16',
             deviceName: 'iPad Pro 12.9 2022',
             deviceOrientation: 'landscape',
-            appiumVersion: '2.15.0',
+            appiumVersion: '2.19.0',
             realMobile: 'true'
           }
         }
@@ -170,7 +170,7 @@ RSpec.describe TestCentricity::WebDriverConnect, browserstack: true do
             osVersion: '12.0',
             deviceName: 'Samsung Galaxy Tab S8',
             deviceOrientation: 'landscape',
-            appiumVersion: '2.15.0',
+            appiumVersion: '2.19.0',
             realMobile: 'true'
           }
         }
@@ -208,7 +208,7 @@ RSpec.describe TestCentricity::WebDriverConnect, browserstack: true do
             os: ENV['BS_OS'],
             osVersion: ENV['BS_OS_VERSION'],
             resolution: ENV['RESOLUTION'],
-            seleniumVersion: '4.30.0'
+            seleniumVersion: '4.35.0'
           }
         }
       }
@@ -300,7 +300,7 @@ RSpec.describe TestCentricity::WebDriverConnect, browserstack: true do
             osVersion: ENV['BS_OS_VERSION'],
             deviceName: 'iPad Pro 12.9 2022',
             deviceOrientation: 'landscape',
-            appiumVersion: '2.15.0',
+            appiumVersion: '2.19.0',
             realMobile: 'true'
           }
         }
@@ -327,7 +327,7 @@ RSpec.describe TestCentricity::WebDriverConnect, browserstack: true do
             osVersion: ENV['BS_OS_VERSION'],
             deviceName: 'Samsung Galaxy Tab S7',
             deviceOrientation: 'landscape',
-            appiumVersion: '2.15.0',
+            appiumVersion: '2.19.0',
             realMobile: 'true'
           }
         }

--- a/spec/testcentricity_web/webdriver_connect/local_webdriver_spec.rb
+++ b/spec/testcentricity_web/webdriver_connect/local_webdriver_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe TestCentricity::WebDriverConnect, required: true do
   include_context 'test_site'
 
   before(:each) do
-    ENV['DOWNLOADS'] = 'false'
+    ENV['DOWNLOADS'] = 'true'
     Dir.delete(WebDriverConnect.downloads_path) if Dir.exist?(WebDriverConnect.downloads_path)
   end
 

--- a/spec/testcentricity_web/webdriver_connect/testingbot_spec.rb
+++ b/spec/testcentricity_web/webdriver_connect/testingbot_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe TestCentricity::WebDriverConnect, testingbot: true do
             build: 'RSpec - DesiredCaps Hash',
             timeZone: ENV['TIME_ZONE'],
             'screen-resolution': ENV['RESOLUTION'],
-            'selenium-version': '4.29.0'
+            'selenium-version': '4.35.0'
           }
         }
       }
@@ -93,7 +93,7 @@ RSpec.describe TestCentricity::WebDriverConnect, testingbot: true do
             build: 'RSpec - DesiredCaps Hash',
             deviceName: 'iPad Pro (12.9-inch) (5th generation)',
             orientation: 'LANDSCAPE',
-            'selenium-version': '4.29.0'
+            'selenium-version': '4.35.0'
           }
         }
       }
@@ -115,7 +115,7 @@ RSpec.describe TestCentricity::WebDriverConnect, testingbot: true do
             build: 'RSpec - DesiredCaps Hash',
             deviceName: 'Galaxy Tab S7',
             orientation: 'LANDSCAPE',
-            'selenium-version': '4.29.0'
+            'selenium-version': '4.35.0'
           }
         }
       }

--- a/testcentricity_web.gemspec
+++ b/testcentricity_web.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.requirements << 'Capybara, Selenium-WebDriver'
 
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'cucumber', '10.0.0'
+  spec.add_development_dependency 'cucumber', '10.1.0'
   spec.add_development_dependency 'cuke_modeler', '~> 3.0'
   spec.add_development_dependency 'docker-compose'
   spec.add_development_dependency 'httparty'
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'require_all', '=1.5.0'
   spec.add_development_dependency 'rspec', '>= 3.13.0'
-  spec.add_development_dependency 'selenium-webdriver', '~>4.34.0'
+  spec.add_development_dependency 'selenium-webdriver', '~>4.35.0'
   spec.add_development_dependency 'simplecov', ['~> 0.18']
   spec.add_development_dependency 'yard', ['>= 0.9.0']
 

--- a/testcentricity_web.gemspec
+++ b/testcentricity_web.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'require_all', '=1.5.0'
   spec.add_development_dependency 'rspec', '>= 3.13.0'
-  spec.add_development_dependency 'selenium-webdriver', '~>4.35.0'
+  spec.add_development_dependency 'selenium-webdriver', '~>4.36.0'
   spec.add_development_dependency 'simplecov', ['~> 0.18']
   spec.add_development_dependency 'yard', ['>= 0.9.0']
 


### PR DESCRIPTION
## Proposed changes

* Update Nokogiri gem to address CVE-2025-6021, CVE-2025-6170, CVE-2025-49794, CVE-2025-49795, and CVE-2025-49796.
* Update REXML gem to address DoS vulnerability when parsing XML containing multiple XML declarations.
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Update gem dependencies
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have added tests (specs and/or Cucumber tests) that prove my fix is effective or that my feature works
- [x] Specs and/or Cucumber tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
