### PR TITLE
Add UIElement.draggable? method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 All notable changes to this project will be documented in this file.
 
 
+## [4.6.7] - 21-OCT-2025
+
+### Added
+
+* Added `UIElement.draggable?` method.
+* Updated `PageObject.verify_ui_states` and `PageSection.verify_ui_states` methods to support verification of the
+ `draggable` property.
+
+
 ## [4.6.6] - 10-OCT-2025
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -570,6 +570,7 @@ With TestCentricity, all UI elements are based on the `UIElement` class, and inh
     element.displayed?
     element.obscured?
     element.focused?
+    element.draggable?
     element.required?
     element.content_editable?
     element.crossorigin
@@ -701,6 +702,7 @@ The `verify_ui_states` method supports the following property/state pairs:
     :hidden            Boolean
     :displayed         Boolean
     :obscured          Boolean
+    :draggable         Boolean
     :width             Integer
     :height            Integer
     :x                 Integer

--- a/features/custom_controls.feature
+++ b/features/custom_controls.feature
@@ -27,3 +27,25 @@ Feature: Custom Controls
       |method |
       |index  |
       |text   |
+
+
+  Scenario Outline: Verify drag and drop actions on UI elements
+    When I drag the <drag> draggable object to the <drop> drop zone
+    Then I expect the <drop> drop zone to <result> the <drag> draggable object
+
+    Examples:
+      |drag   |drop   |result |
+      |first  |first  |accept |
+      |second |first  |reject |
+      |first  |second |accept |
+      |second |second |accept |
+
+
+  Scenario Outline: Verify drag by offset actions on UI elements
+    When I drag the <drag> drag object to the <direction>
+    Then I expect the drop zones to be empty
+
+    Examples:
+      |drag   |direction |
+      |first  |left      |
+      |second |right     |

--- a/features/step_definitions/generic_steps.rb
+++ b/features/step_definitions/generic_steps.rb
@@ -157,3 +157,23 @@ end
 When(/^I (.*) product card (.*)$/) do |action, num|
   indexed_sections_page.card_action(action, num.to_i)
 end
+
+
+When(/^I drag the (.*) draggable object to the (.*) drop zone$/) do |drag_object, drop_zone|
+  custom_controls_page.drag_to_drop_zone(drag_object, drop_zone)
+end
+
+
+Then(/^I expect the (.*) drop zone to (.*) the (.*) draggable object$/) do |drop_zone, result, drag_object|
+  custom_controls_page.verify_dropped(drag_object, drop_zone, result)
+end
+
+
+When(/^I drag the (.*) drag object to the (.*)$/) do |drag_object, direction|
+  custom_controls_page.drag_by(drag_object, direction)
+end
+
+
+Then(/^I expect the drop zones to be empty$/) do
+  custom_controls_page.verify_no_drops
+end

--- a/features/support/pages/basic_form_page.rb
+++ b/features/support/pages/basic_form_page.rb
@@ -180,6 +180,7 @@ class BasicFormPage < BaseTestPage
         enabled: true,
         disabled: false,
         required: true,
+        draggable: false,
         value: '',
         placeholder: 'User name',
         title: 'User Name',
@@ -204,6 +205,7 @@ class BasicFormPage < BaseTestPage
         focused: false,
         enabled: true,
         required: true,
+        draggable: false,
         value: '',
         placeholder: 'Password',
         title: 'Password'
@@ -268,6 +270,7 @@ class BasicFormPage < BaseTestPage
         disabled: false,
         checked: false,
         indeterminate: false,
+        draggable: false,
         caption: { translate_downcase: 'base_form_page.checkbox1' }
       },
       check_2 => {
@@ -308,6 +311,7 @@ class BasicFormPage < BaseTestPage
         enabled: true,
         disabled: false,
         selected: false,
+        draggable: false,
         caption: { translate_upcase: 'base_form_page.radio1' }
       },
       radio_2 => {
@@ -341,6 +345,7 @@ class BasicFormPage < BaseTestPage
       multi_select => {
         visible: true,
         enabled: true,
+        draggable: false,
         optioncount: 4,
         options: ['Selection Item 1', 'Selection Item 2', 'Selection Item 3', 'Selection Item 4'],
         selected: ''
@@ -357,6 +362,7 @@ class BasicFormPage < BaseTestPage
       links_list => {
         visible: true,
         enabled: true,
+        draggable: false,
         itemcount: 3,
         items: ['Open Media Page in same window/tab', 'Open Media Page in a new window/tab', 'Disabled Link'],
         { item: 1 } => ['Open Media Page in same window/tab'],
@@ -381,6 +387,7 @@ class BasicFormPage < BaseTestPage
       table_label => { visible: true, caption: 'Table:' },
       static_table => {
         visible: true,
+        draggable: false,
         columncount: 3,
         rowcount: 4,
         column_headers: %w[Company Contact Country],
@@ -423,8 +430,16 @@ class BasicFormPage < BaseTestPage
         alt: 'Tiny Violin',
         style: { contains: 'border-radius: 50%;' }
       },
-      cancel_button => { visible: true, enabled: true, caption: { translate_capitalize: 'base_form_page.cancel_button' } },
-      submit_button => { visible: true, enabled: true, caption: { translate_capitalize: 'base_form_page.submit_button' } }
+      cancel_button => {
+        visible: true,
+        enabled: true,
+        caption: { translate_capitalize: 'base_form_page.cancel_button' }
+      },
+      submit_button => {
+        visible: true,
+        enabled: true,
+        caption: { translate_capitalize: 'base_form_page.submit_button' }
+      }
     }
     verify_ui_states(ui)
 

--- a/lib/testcentricity_web/version.rb
+++ b/lib/testcentricity_web/version.rb
@@ -1,3 +1,3 @@
 module TestCentricityWeb
-  VERSION = '4.6.6'
+  VERSION = '4.6.7'
 end

--- a/lib/testcentricity_web/web_core/page_objects_helper.rb
+++ b/lib/testcentricity_web/web_core/page_objects_helper.rb
@@ -69,6 +69,8 @@ module TestCentricity
                      ui_object.obscured?
                    when :focused
                      ui_object.focused?
+                   when :draggable
+                     ui_object.draggable?
                    when :width
                      ui_object.width
                    when :height

--- a/lib/testcentricity_web/web_elements/ui_element.rb
+++ b/lib/testcentricity_web/web_elements/ui_element.rb
@@ -559,6 +559,21 @@ module TestCentricity
         obj.displayed?
       end
 
+      # Return state of UI object's draggable property
+      #
+      # @return [Boolean]
+      # @example
+      #   puzzle_piece_21.draggable?
+      #
+      def draggable?
+        state = get_attribute(:draggable)
+        if state.is_a?(String)
+          state.to_bool
+        elsif state.boolean?
+          state
+        end
+      end
+
       def get_value(visible = true)
         obj, type = find_element(visible)
         object_not_found_exception(obj, type)

--- a/spec/testcentricity_web/elements/ui_element_spec.rb
+++ b/spec/testcentricity_web/elements/ui_element_spec.rb
@@ -103,6 +103,11 @@ RSpec.describe TestCentricity::Elements::UIElement, required: true do
     expect(css_element.displayed?).to eq(true)
   end
 
+  it 'should know if element is draggable' do
+    allow(css_element).to receive(:draggable?).and_return(true)
+    expect(css_element.draggable?).to eq(true)
+  end
+
   it 'should know if element is required' do
     allow(css_element).to receive(:required?).and_return(true)
     expect(css_element.required?).to eq(true)

--- a/test_site/custom_controls_page.html
+++ b/test_site/custom_controls_page.html
@@ -172,6 +172,53 @@
             display: table-cell;
             padding: 6px;
         }
+        .drags{
+            width: 300px;
+            height: 150px;
+            margin: auto;
+            overflow: hidden;
+        }
+        .drag{
+            width: 150px;
+            display: inline;
+            min-width: 150px;
+        }
+        .left{
+            float: left;
+        }
+        .right{
+            float: right;
+        }
+        .draggable{
+            font-size: 1.2em;
+            font-family: Arial, "Helvetica Neue", Helvetica, sans-serif;
+            font-style: normal;
+            font-variant: normal;
+            width: 100px;
+            height: 100px;
+            padding: 0.5em;
+            float: left;
+            margin: 10px 10px 10px 0;
+            background-color: yellow;
+        }
+        .drops{
+            width: 800px;
+            height: 400px;
+            margin: auto;
+            overflow: hidden;
+        }
+        .droppable{
+            font-size: 1.2em;
+            font-family: Arial, "Helvetica Neue", Helvetica, sans-serif;
+            font-style: normal;
+            font-variant: normal;
+            width: 250px;
+            height: 250px;
+            padding: 0.5em;
+            float: left;
+            margin: 10px;
+            background-color: green;
+        }
     </style>
 </head>
 <body>
@@ -614,7 +661,32 @@
                     </div>
                 </div>
             </td>
+        </tr>
+        <tr>
             <td>
+                <h3>Draggable Elements</h3>
+                <div class="draganddrops">
+                    <div class="drags">
+                        <div class="drag left">
+                            <div id="draggable1" class="draggable">
+                                <p>Drag me</p>
+                            </div>
+                        </div>
+                        <div class="drag right">
+                            <div id="draggable2" class="draggable">
+                                <p>Drag me</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="drops">
+                        <div id="droppable1" class="droppable">
+                            <p>Drop here</p>
+                        </div>
+                        <div id="droppable2" class="droppable">
+                            <p>No Drop here</p>
+                        </div>
+                    </div>
+                </div>
 
             </td>
         </tr>
@@ -633,6 +705,121 @@
 <script src="chosen/chosen.jquery.js" type="text/javascript"></script>
 <script src="docsupport/prism.js" type="text/javascript" charset="utf-8"></script>
 <script src="docsupport/init.js" type="text/javascript" charset="utf-8"></script>
+
+<script>
+    // references
+    // https://www.w3schools.com/howto/howto_js_draggable.asp
+    // https://javascript.info/mouse-drag-and-drop
+    function draggable(element) {
+        var shiftX, shiftY;
+        var elemsBelow;
+
+        element.onmousedown = dragMouseDown;
+
+        function moveAt(pageX, pageY) {
+            element.style.left = pageX - shiftX + 'px';
+            element.style.top = pageY - shiftY + 'px';
+
+        }
+
+        function dragMouseDown(e) {
+            shiftX = e.clientX - element.getBoundingClientRect().left;
+            shiftY = e.clientY - element.getBoundingClientRect().top;
+
+            element.style.position = 'absolute';
+            element.style.zIndex = 1000;
+            document.body.append(element);
+            moveAt(e.pageX, e.pageY);
+
+            document.addEventListener("mouseup", closeDragElement);
+            document.addEventListener("mousemove", elementDrag);
+        }
+
+        function elementDrag(e) {
+
+            element.hidden = true;
+            elemsBelow = document.elementsFromPoint(e.clientX, e.clientY);
+            element.hidden = false;
+
+            moveAt(e.pageX, e.pageY);
+        }
+
+        function closeDragElement() {
+
+            dropped(element, elemsBelow);
+
+            document.removeEventListener('mousemove', elementDrag);
+            document.removeEventListener('mouseup', closeDragElement);
+        }
+    }
+
+    function dropped(droppee, ontoa) {
+        try {
+            // for each of the elements in ontoa
+            for(var x=0; x<ontoa.length; x++) {
+                var onto = ontoa[x];
+                if (onto.getAttribute("id") == "droppable1") {
+                    if (droppee.getAttribute("id") == "draggable1") {
+                        onto.getElementsByTagName("p")[0].innerHTML = "Dropped!";
+                    }
+                    if (droppee.getAttribute("id") == "draggable2") {
+                        onto.getElementsByTagName("p")[0].innerHTML = "Get Off Me!";
+                    }
+                } else {
+                    if(onto.getAttribute("class")){
+                        if (onto.getAttribute("class").includes("droppable")) {
+                            onto.getElementsByTagName("p")[0].innerHTML = "Dropped!";
+                        }
+                    }
+                }
+            }
+        } catch (err) {
+            console.log(err);
+        }
+    }
+
+    draggable(document.getElementById("draggable1"));
+    draggable(document.getElementById("draggable2"));
+
+    document.addEventListener("keydown", function (event) {
+
+        // var control = document.getElementById("keyeventslist")
+        // var currcount = parseInt(control.getAttribute("data-count"))
+        // control.setAttribute("data-count", (currcount+1).toString())
+        //
+        // var elem = document.createElement("p");
+        // elem.setAttribute("id", "event" + (currcount+1).toString());
+        // elem.setAttribute("data-added-at", Date.now());
+        // elem.setAttribute("class", "eventdata");
+        // elem.appendChild(document.createTextNode("down " + event.key));
+        // control.prepend(elem);
+        //
+        // // var li = document.createElement("li");
+        // // li.appendChild(document.createTextNode("down " + event.key));
+        // document.getElementById("keyeventslist").prepend(elem);
+
+        if (event.ctrlKey) cntrlPressed = true;
+
+        if (event.key == " " && cntrlPressed) {
+            // ctrl space
+            document.getElementById("droppable1").getElementsByTagName("p")[0].innerHTML = "Let GO!!!";
+            document.getElementById("droppable2").getElementsByTagName("p")[0].innerHTML = "Let GO!!!";
+        }
+
+        if (event.key == "b" && cntrlPressed) {
+            // ctrl B
+            document.getElementById("draggable1").getElementsByTagName("p")[0].innerHTML = "Bwa! Ha! Ha!";
+        }
+    });
+
+    // change text on droppables to "Drop Here"
+    document.addEventListener("keyup", function (event) {
+        if (!event.ctrlKey) cntrlPressed = false;
+        document.getElementById("droppable1").getElementsByTagName("p")[0].innerHTML = "Drop Here";
+        document.getElementById("droppable2").getElementsByTagName("p")[0].innerHTML = "Drop Here";
+    });
+</script>
+
 
 </body>
 </html>

--- a/testcentricity_web.gemspec
+++ b/testcentricity_web.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.requirements << 'Capybara, Selenium-WebDriver'
 
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'cucumber', '10.1.0'
+  spec.add_development_dependency 'cucumber', '10.1.1'
   spec.add_development_dependency 'cuke_modeler', '~> 3.0'
   spec.add_development_dependency 'docker-compose'
   spec.add_development_dependency 'httparty'
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'require_all', '=1.5.0'
   spec.add_development_dependency 'rspec', '>= 3.13.0'
-  spec.add_development_dependency 'selenium-webdriver', '~>4.36.0'
+  spec.add_development_dependency 'selenium-webdriver', '~>4.37.0'
   spec.add_development_dependency 'simplecov', ['~> 0.18']
   spec.add_development_dependency 'yard', ['>= 0.9.0']
 


### PR DESCRIPTION
## Proposed changes

* Added `UIElement.draggable?` method.
* Updated `PageObject.verify_ui_states` and `PageSection.verify_ui_states` methods to support verification of the
 `draggable` property.
* Added specs and features to verify`UIElement.drag_by`, `UIElement.drag_and_drop`, and `UIElement.draggable?` methods.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have added tests (specs and/or Cucumber tests) that prove my fix is effective or that my feature works
- [x] Specs and/or Cucumber tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules