### PR TITLE
Ad activesupport gem as a runtime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 
 
+## [4.7.1] - 13-JAN-2026
+
+### Fixed
+* Added `activesupport` gem as a runtime dependency to prevent test failures if gem is not already installed.
+
+
 ## [4.7.0] - 12-JAN-2026
 
 ### Added

--- a/lib/testcentricity_web/version.rb
+++ b/lib/testcentricity_web/version.rb
@@ -1,3 +1,3 @@
 module TestCentricityWeb
-  VERSION = '4.7.0'
+  VERSION = '4.7.1'
 end

--- a/testcentricity_web.gemspec
+++ b/testcentricity_web.gemspec
@@ -33,7 +33,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.requirements << 'Capybara, Selenium-WebDriver'
 
-  spec.add_development_dependency 'activesupport', '>= 4.0'
   spec.add_development_dependency 'axe-core-cucumber'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'cucumber', '10.2.0'
@@ -48,6 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', ['~> 0.18']
   spec.add_development_dependency 'yard', ['>= 0.9.0']
 
+  spec.add_runtime_dependency 'activesupport', '>= 4.0'
   spec.add_runtime_dependency 'appium_lib', '~> 16.1.1'
   spec.add_runtime_dependency 'browserstack-local'
   spec.add_runtime_dependency 'capybara', '3.40.0'


### PR DESCRIPTION
## Proposed changes

* Added `activesupport` gem as a runtime dependency to prevent test failures if gem is not already installed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have added tests (specs and/or Cucumber tests) that prove my fix is effective or that my feature works
- [x] Specs and/or Cucumber tests pass locally with my changes
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules